### PR TITLE
Integrate ZeptoMail API into Zoho Tool

### DIFF
--- a/langchain-agents/config.py
+++ b/langchain-agents/config.py
@@ -19,6 +19,7 @@ class Config:
     # Zoho
     ZOHO_API_KEY = os.getenv("ZOHO_API_KEY")
     ZOHO_FROM_EMAIL = os.getenv("ZOHO_FROM_EMAIL", "info@xcellent1lawncare.com")
+    ZOHO_FROM_NAME = os.getenv("ZOHO_FROM_NAME", "Xcellent1 Lawn Care")
 
     # Business Pricing
     BASE_PRICE_PER_SQFT = float(os.getenv("BASE_PRICE_PER_SQFT", "0.02"))

--- a/langchain-agents/requirements.txt
+++ b/langchain-agents/requirements.txt
@@ -1,6 +1,7 @@
 flask>=2.2.5
 flask-cors>=3.0.10
 python-dotenv>=1.0.0
+requests>=2.31.0
 # langchain and community packages are optional heavy deps; add when enabling LLMs
 # langchain>=0.0.361
 # langchain-community>=0.0.5

--- a/langchain-agents/tools/zoho_tool.py
+++ b/langchain-agents/tools/zoho_tool.py
@@ -1,6 +1,80 @@
-"""Placeholder Zoho email tool. Replace with Zoho Mail API integration."""
+"""Zoho email tool using ZeptoMail API."""
+import requests
+import json
+import os
+import sys
+
+# Attempt imports to handle different execution contexts
+try:
+    from config import Config
+except ImportError:
+    try:
+        from ..config import Config
+    except ImportError:
+        # Fallback for direct execution
+        sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        from config import Config
 
 
 def send_email(to: str, subject: str, body: str):
-    # TODO: integrate with Zoho Mail API
-    return {"status": "mocked", "to": to, "subject": subject}
+    """
+    Sends an email using the ZeptoMail API.
+
+    Args:
+        to (str): Recipient email address.
+        subject (str): Email subject.
+        body (str): HTML body of the email.
+
+    Returns:
+        dict: Status and response details.
+    """
+    # ZeptoMail API endpoint (US)
+    url = "https://api.zeptomail.com/v1.1/email"
+
+    api_key = Config.ZOHO_API_KEY
+    from_email = Config.ZOHO_FROM_EMAIL
+    from_name = getattr(Config, "ZOHO_FROM_NAME", "Xcellent1 Lawn Care")
+
+    if not api_key:
+        return {"status": "error", "message": "ZOHO_API_KEY not configured"}
+
+    headers = {
+        "Authorization": api_key,
+        "Content-Type": "application/json",
+        "Accept": "application/json"
+    }
+
+    payload = {
+        "from": {
+            "address": from_email,
+            "name": from_name
+        },
+        "to": [
+            {
+                "email_address": {
+                    "address": to
+                }
+            }
+        ],
+        "subject": subject,
+        "htmlbody": body
+    }
+
+    try:
+        response = requests.post(url, headers=headers, json=payload, timeout=10)
+        response.raise_for_status()
+        return {"status": "success", "data": response.json()}
+    except requests.exceptions.RequestException as e:
+        error_details = None
+        if 'response' in locals() and response is not None:
+            try:
+                error_details = response.text
+            except ValueError:
+                pass
+
+        return {
+            "status": "error",
+            "message": str(e),
+            "details": error_details,
+            "to": to
+        }


### PR DESCRIPTION
Replaced the mock email tool with a functional implementation using the ZeptoMail API. This allows the agent to send actual emails. The implementation uses the provided `ZOHO_API_KEY` (mapped to Send Mail Token) and `ZOHO_FROM_EMAIL`. Also added `ZOHO_FROM_NAME` configuration to avoid hardcoding the business name.

---
*PR created automatically by Jules for task [15455305037017597125](https://jules.google.com/task/15455305037017597125) started by @Thelastlineofcode*