### PR TITLE
Webapp Platform: Supabase event stubs, schema additions, and crew/owner UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,11 @@ build/
 .deno/
 
 # Supabase CLI binary (downloaded)
+# NOTE: This repo also uses `supabase/` for edge functions + migrations.
+# Ignore the binary but keep the directory tracked.
 supabase
+!supabase/
+!supabase/**
 
 # Logs
 *.log

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -131,6 +131,55 @@ CREATE TABLE IF NOT EXISTS payment_accounts (
   UNIQUE(user_id, payment_method, account_identifier)
 );
 
+-- =============================================================
+-- Webapp Platform (Issue #27) schema additions (Module 1 + 3)
+-- =============================================================
+
+-- Worker applications (public intake)
+CREATE TABLE IF NOT EXISTS worker_applications (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  auth_user_id UUID,
+  name TEXT NOT NULL,
+  phone TEXT NOT NULL,
+  email TEXT,
+  equipment_owned JSONB DEFAULT '[]',
+  availability JSONB DEFAULT '{}',
+  service_areas TEXT[] DEFAULT '{}',
+  status TEXT DEFAULT 'pending' CHECK (status IN ('pending', 'approved', 'rejected')),
+  applied_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Crew performance scores (calculated periodically)
+CREATE TABLE IF NOT EXISTS performance_scores (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  worker_id UUID REFERENCES users(id),
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  jobs_completed INT DEFAULT 0,
+  jobs_on_time INT DEFAULT 0,
+  quality_score DECIMAL(4,2),
+  status TEXT DEFAULT 'green' CHECK (status IN ('green', 'yellow', 'red')),
+  calculated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Notification audit log (source of truth for dedupe)
+CREATE TABLE IF NOT EXISTS notifications_log (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  recipient_type TEXT CHECK (recipient_type IN ('owner', 'crew', 'customer')),
+  recipient_id UUID,
+  channel TEXT CHECK (channel IN ('sms', 'email', 'push')),
+  event_type TEXT NOT NULL,
+  ref_id TEXT,
+  payload JSONB DEFAULT '{}',
+  sent_at TIMESTAMPTZ DEFAULT NOW(),
+  status TEXT DEFAULT 'sent' CHECK (status IN ('sent', 'failed', 'bounced'))
+);
+
+-- Extend jobs table for comms + tracking
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS completion_photo_url TEXT;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS crew_en_route_at TIMESTAMPTZ;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS started_at TIMESTAMPTZ;
+
 -- Outbox events table (event sourcing)
 CREATE TABLE IF NOT EXISTS outbox_events (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -164,6 +213,42 @@ CREATE INDEX IF NOT EXISTS idx_payment_accounts_user ON payment_accounts(user_id
 CREATE INDEX IF NOT EXISTS idx_payment_accounts_method ON payment_accounts(payment_method);
 CREATE INDEX IF NOT EXISTS idx_payment_accounts_primary ON payment_accounts(user_id, is_primary) WHERE is_primary = TRUE;
 
+-- Webapp Platform indexes
+CREATE INDEX IF NOT EXISTS idx_performance_scores_worker ON performance_scores(worker_id, period_start);
+CREATE INDEX IF NOT EXISTS idx_notifications_log_event ON notifications_log(event_type, sent_at);
+CREATE INDEX IF NOT EXISTS idx_worker_applications_status ON worker_applications(status);
+
+-- Dedupe: avoid sending the same notification twice for same ref
+CREATE UNIQUE INDEX IF NOT EXISTS idx_notifications_log_dedupe
+  ON notifications_log(event_type, channel, recipient_type, ref_id)
+  WHERE ref_id IS NOT NULL;
+
+-- Enable Supabase Realtime on key tables.
+-- Guarded so running this schema in non-Supabase Postgres doesn't error.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime') THEN
+    -- jobs
+    IF to_regclass('public.jobs') IS NOT NULL THEN
+      BEGIN
+        ALTER PUBLICATION supabase_realtime ADD TABLE public.jobs;
+      EXCEPTION WHEN duplicate_object THEN
+        -- already added
+      END;
+    END IF;
+
+    -- leads (only if the table exists in this project)
+    IF to_regclass('public.leads') IS NOT NULL THEN
+      BEGIN
+        ALTER PUBLICATION supabase_realtime ADD TABLE public.leads;
+      EXCEPTION WHEN duplicate_object THEN
+        -- already added
+      END;
+    END IF;
+  END IF;
+END;
+$$;
+
 -- Row Level Security (RLS) policies
 ALTER TABLE users ENABLE ROW LEVEL SECURITY;
 ALTER TABLE applications ENABLE ROW LEVEL SECURITY;
@@ -173,6 +258,9 @@ ALTER TABLE job_photos ENABLE ROW LEVEL SECURITY;
 ALTER TABLE invoices ENABLE ROW LEVEL SECURITY;
 ALTER TABLE payments ENABLE ROW LEVEL SECURITY;
 ALTER TABLE payment_accounts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE worker_applications ENABLE ROW LEVEL SECURITY;
+ALTER TABLE performance_scores ENABLE ROW LEVEL SECURITY;
+ALTER TABLE notifications_log ENABLE ROW LEVEL SECURITY;
 
 -- RLS Policies for role-based access
 -- Helper function to get user role from auth.uid()
@@ -233,6 +321,38 @@ CREATE POLICY "Clients can view own payments" ON payments FOR SELECT
 -- Payment accounts policies
 CREATE POLICY "Owners can manage their payment accounts" ON payment_accounts FOR ALL
   USING (user_id IN (SELECT id FROM users WHERE auth_user_id = auth.uid()));
+
+-- Worker applications policies
+CREATE POLICY "owner_can_view_all_applications" ON worker_applications
+  FOR SELECT USING (auth.user_role() = 'owner');
+
+CREATE POLICY "applicant_can_view_own" ON worker_applications
+  FOR SELECT USING (auth.uid() = auth_user_id);
+
+CREATE POLICY "public_can_insert_worker_applications" ON worker_applications
+  FOR INSERT WITH CHECK (true);
+
+CREATE POLICY "owner_can_update_applications" ON worker_applications
+  FOR UPDATE USING (auth.user_role() = 'owner');
+
+-- Performance scores policies
+CREATE POLICY "owner_can_view_all_scores" ON performance_scores
+  FOR SELECT USING (auth.user_role() = 'owner');
+
+CREATE POLICY "crew_can_view_own_scores" ON performance_scores
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM users u
+      WHERE u.id = performance_scores.worker_id
+        AND u.auth_user_id = auth.uid()
+        AND u.role = 'crew'
+    )
+  );
+
+-- Notifications log policies
+CREATE POLICY "owner_can_view_notifications" ON notifications_log
+  FOR SELECT USING (auth.user_role() = 'owner');
 
 -- Insert demo data (optional)
 INSERT INTO users (email, phone, name, role) VALUES

--- a/server.ts
+++ b/server.ts
@@ -1243,6 +1243,71 @@ async function handler(req: Request): Promise<Response> {
     }
   }
 
+  // GET /api/crew/performance (crew self-view)
+  if (url.pathname === "/api/crew/performance" && req.method === "GET") {
+    // Require crew authentication
+    const authCheck = await requireAuth(req, ["crew"]);
+    if (!authCheck.authorized) return (authCheck as any).response;
+
+    try {
+      if (!dbConnected) {
+        // Safe mock for demo mode
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            status: "green",
+            period_start: null,
+            period_end: null,
+            jobs_completed: 0,
+            jobs_on_time: 0,
+            quality_score: null,
+          }),
+          { status: 200, headers },
+        );
+      }
+
+      const crewUserId = authCheck.auth.profile.id;
+
+      // Latest calculated row for this crew member
+      const result = await db.queryObject(
+        `
+          SELECT status, period_start, period_end, jobs_completed, jobs_on_time, quality_score, calculated_at
+          FROM performance_scores
+          WHERE worker_id = $1
+          ORDER BY calculated_at DESC
+          LIMIT 1
+        `,
+        [crewUserId],
+      );
+
+      if (result.rows.length === 0) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            status: "green",
+            period_start: null,
+            period_end: null,
+            jobs_completed: 0,
+            jobs_on_time: 0,
+            quality_score: null,
+          }),
+          { status: 200, headers },
+        );
+      }
+
+      return new Response(JSON.stringify({ ok: true, ...result.rows[0] }), {
+        status: 200,
+        headers,
+      });
+    } catch (err) {
+      console.error("[server] Error getting crew performance:", err);
+      return new Response(
+        JSON.stringify({ ok: false, error: "Internal server error" }),
+        { status: 500, headers },
+      );
+    }
+  }
+
   // GET /api/owner/metrics (business KPIs)
   if (url.pathname === "/api/owner/metrics" && req.method === "GET") {
     // Require owner authentication

--- a/supabase/functions/_shared/notifications.ts
+++ b/supabase/functions/_shared/notifications.ts
@@ -1,0 +1,197 @@
+export interface NotificationEvent {
+  type: string;
+  payload: Record<string, unknown>;
+  job_id?: string;
+  lead_id?: string;
+  invoice_id?: string;
+  worker_id?: string;
+}
+
+export interface NotificationResult {
+  sms_sent: boolean;
+  email_sent: boolean;
+  push_sent: boolean;
+  errors: string[];
+}
+
+async function notificationAlreadyLogged(
+  recipientType: "owner" | "crew" | "customer",
+  channel: "sms" | "email" | "push",
+  eventType: string,
+  refId: string | undefined,
+): Promise<boolean> {
+  if (!refId) return false;
+
+  const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+  const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    // Can't dedupe without the log source of truth.
+    return false;
+  }
+
+  try {
+    const url = new URL(`${SUPABASE_URL}/rest/v1/notifications_log`);
+    url.searchParams.set("select", "id");
+    url.searchParams.set("event_type", `eq.${eventType}`);
+    url.searchParams.set("channel", `eq.${channel}`);
+    url.searchParams.set("recipient_type", `eq.${recipientType}`);
+    url.searchParams.set("ref_id", `eq.${refId}`);
+    url.searchParams.set("status", "eq.sent");
+    url.searchParams.set("limit", "1");
+
+    const res = await fetch(url.toString(), {
+      method: "GET",
+      headers: {
+        "apikey": SUPABASE_SERVICE_ROLE_KEY,
+        "Authorization": `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+        "Accept": "application/json",
+      },
+    });
+
+    if (!res.ok) return false;
+    const rows = await res.json();
+    return Array.isArray(rows) && rows.length > 0;
+  } catch (err) {
+    console.warn("notificationAlreadyLogged check failed:", err);
+    return false;
+  }
+}
+
+export async function shouldSendNotification(
+  recipientType: "owner" | "crew" | "customer",
+  channel: "sms" | "email" | "push",
+  eventType: string,
+  refId: string | undefined,
+): Promise<boolean> {
+  const already = await notificationAlreadyLogged(
+    recipientType,
+    channel,
+    eventType,
+    refId,
+  );
+  return !already;
+}
+
+export async function sendSMS(to: string, body: string): Promise<boolean> {
+  const TWILIO_ACCOUNT_SID = Deno.env.get("TWILIO_ACCOUNT_SID");
+  const TWILIO_AUTH_TOKEN = Deno.env.get("TWILIO_AUTH_TOKEN");
+  const TWILIO_PHONE_NUMBER = Deno.env.get("TWILIO_PHONE_NUMBER");
+  
+  if (!TWILIO_ACCOUNT_SID || !TWILIO_AUTH_TOKEN || !TWILIO_PHONE_NUMBER) {
+    console.warn("Twilio credentials not configured, skipping SMS");
+    return false;
+  }
+  
+  try {
+    const url = `https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Authorization": `Basic ${btoa(`${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}`)}`,
+      },
+      body: new URLSearchParams({
+        From: TWILIO_PHONE_NUMBER,
+        To: to,
+        Body: body,
+      }),
+    });
+    
+    if (!response.ok) {
+      const error = await response.text();
+      console.error("Twilio SMS error:", error);
+      return false;
+    }
+    
+    return true;
+  } catch (err) {
+    console.error("Twilio SMS failed:", err);
+    return false;
+  }
+}
+
+export async function sendEmail(to: string, subject: string, html: string): Promise<boolean> {
+  const SENDGRID_API_KEY = Deno.env.get("SENDGRID_API_KEY");
+  const FROM_EMAIL = Deno.env.get("SENDGRID_FROM_EMAIL") || "noreply@xcellent1lawn.com";
+  
+  if (!SENDGRID_API_KEY) {
+    console.warn("SendGrid API key not configured, skipping email");
+    return false;
+  }
+  
+  try {
+    const response = await fetch("https://api.sendgrid.com/v3/mail/send", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${SENDGRID_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        personalizations: [{ to: [{ email: to }] }],
+        from: { email: FROM_EMAIL },
+        subject,
+        content: [{ type: "text/html", value: html }],
+      }),
+    });
+    
+    if (response.status !== 202) {
+      const error = await response.text();
+      console.error("SendGrid email error:", error);
+      return false;
+    }
+    
+    return true;
+  } catch (err) {
+    console.error("SendGrid email failed:", err);
+    return false;
+  }
+}
+
+export async function logNotification(
+  recipientType: "owner" | "crew" | "customer",
+  recipientId: string | undefined,
+  channel: "sms" | "email" | "push",
+  eventType: string,
+  refId: string | undefined,
+  payload: Record<string, unknown>,
+  status: "sent" | "failed" | "bounced" = "sent"
+): Promise<void> {
+  const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+  const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    console.warn("Supabase credentials not configured, skipping notification log");
+    return;
+  }
+  
+  try {
+    const res = await fetch(`${SUPABASE_URL}/rest/v1/notifications_log`, {
+      method: "POST",
+      headers: {
+        "apikey": SUPABASE_SERVICE_ROLE_KEY,
+        "Authorization": `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+        "Content-Type": "application/json",
+        "Prefer": "return=minimal",
+      },
+      body: JSON.stringify({
+        recipient_type: recipientType,
+        recipient_id: recipientId,
+        channel,
+        event_type: eventType,
+        ref_id: refId,
+        payload,
+        status,
+      }),
+    });
+
+    // If the DB has a unique index for dedupe, a duplicate insert can return 409.
+    // In that case we intentionally ignore it.
+    if (!(res.ok || res.status === 409)) {
+      const text = await res.text().catch(() => "");
+      console.warn("Notification log insert failed:", res.status, text);
+    }
+  } catch (err) {
+    console.error("Failed to log notification:", err);
+  }
+}

--- a/supabase/functions/crew-en-route/index.ts
+++ b/supabase/functions/crew-en-route/index.ts
@@ -1,0 +1,25 @@
+import { sendSMS, logNotification, shouldSendNotification } from "../_shared/notifications.ts";
+
+// Event: Crew en route — Customer SMS with ETA
+// Triggered when crew marks "en route" in app
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== "POST") return new Response("Method not allowed", { status: 405 });
+  
+  const { job_id, customer_phone, address, eta_minutes } = await req.json();
+
+  if (!(await shouldSendNotification("customer", "sms", "crew_en_route", job_id))) {
+    return new Response(JSON.stringify({ ok: true, skipped: "Duplicate crew_en_route" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  
+  const smsOk = await sendSMS(customer_phone, `🚗 Your crew is en route! ETA: ~${eta_minutes || 15} minutes. Address: ${address}`);
+  await logNotification("customer", undefined, "sms", "crew_en_route", job_id, { job_id, eta_minutes }, smsOk ? "sent" : "failed");
+  
+  return new Response(JSON.stringify({ ok: smsOk }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+});

--- a/supabase/functions/crew-red-status/index.ts
+++ b/supabase/functions/crew-red-status/index.ts
@@ -1,0 +1,52 @@
+import { sendSMS, logNotification, shouldSendNotification } from "../_shared/notifications.ts";
+
+// Event: Crew red status — Owner SMS + Crew self-view update
+// Triggered when performance score drops below threshold
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== "POST") return new Response("Method not allowed", { status: 405 });
+  
+  const { worker_id, worker_name, worker_phone, period_start, period_end, quality_score, jobs_on_time, jobs_completed } = await req.json();
+  
+  const ownerPhone = Deno.env.get("OWNER_PHONE") || "";
+  
+  // Owner SMS alert (deduped by worker_id for the event)
+  let ownerSmsOk = true;
+  if (await shouldSendNotification("owner", "sms", "crew_red_status", worker_id)) {
+    ownerSmsOk = await sendSMS(
+      ownerPhone,
+      `🔴 Red status alert: ${worker_name}. Quality: ${quality_score || "N/A"}. On-time: ${jobs_on_time}/${jobs_completed}. Period: ${period_start} to ${period_end}`,
+    );
+    await logNotification(
+      "owner",
+      undefined,
+      "sms",
+      "crew_red_status",
+      worker_id,
+      { worker_id, worker_name },
+      ownerSmsOk ? "sent" : "failed",
+    );
+  }
+  
+  // Crew self-view SMS (deduped by worker_id for the event)
+  if (worker_phone && await shouldSendNotification("crew", "sms", "crew_red_status", worker_id)) {
+    const crewSmsOk = await sendSMS(
+      worker_phone,
+      `🔴 Your performance status is RED. Quality: ${quality_score || "N/A"}. On-time: ${jobs_on_time}/${jobs_completed}. Please contact your supervisor.`,
+    );
+    await logNotification(
+      "crew",
+      worker_id,
+      "sms",
+      "crew_red_status",
+      worker_id,
+      { worker_id },
+      crewSmsOk ? "sent" : "failed",
+    );
+  }
+  
+  return new Response(JSON.stringify({ ok: ownerSmsOk }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+});

--- a/supabase/functions/invoice-overdue-14d/index.ts
+++ b/supabase/functions/invoice-overdue-14d/index.ts
@@ -1,0 +1,62 @@
+import {
+  sendSMS,
+  sendEmail,
+  logNotification,
+  shouldSendNotification,
+} from "../_shared/notifications.ts";
+
+// Event: Invoice overdue 14 days
+// Triggered by cron (daily)
+// Sends: Owner SMS alert + Customer email escalation
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== "POST") return new Response("Method not allowed", { status: 405 });
+  
+  const { invoice_id, customer_email, customer_name, amount, due_date } = await req.json();
+  
+  const ownerPhone = Deno.env.get("OWNER_PHONE") || "";
+  
+  // Owner SMS escalation (deduped by invoice_id)
+  let ownerSmsOk = true;
+  if (await shouldSendNotification("owner", "sms", "invoice_overdue_14d", invoice_id)) {
+    ownerSmsOk = await sendSMS(
+      ownerPhone,
+      `⚠️ Invoice ${invoice_id?.slice(0, 8)} is 14 days overdue: $${amount} from ${customer_name}`,
+    );
+    await logNotification(
+      "owner",
+      undefined,
+      "sms",
+      "invoice_overdue_14d",
+      invoice_id,
+      { invoice_id, amount },
+      ownerSmsOk ? "sent" : "failed",
+    );
+  }
+  
+  // Customer email escalation (deduped by invoice_id)
+  let emailOk = true;
+  if (await shouldSendNotification("customer", "email", "invoice_overdue_14d", invoice_id)) {
+    const html =
+      `<h2>Urgent: Overdue Invoice</h2><p>Dear ${customer_name},</p><p>Invoice #${invoice_id?.slice(0, 8)} for $${amount} was due on ${due_date} and is now 14 days overdue.</p><p>Please submit payment immediately to avoid service interruption.</p><p>Call us at (504) 875-8079 to discuss payment options.</p>`;
+    emailOk = await sendEmail(
+      customer_email,
+      "URGENT: Overdue Invoice - Xcellent1 Lawn Care",
+      html,
+    );
+    await logNotification(
+      "customer",
+      undefined,
+      "email",
+      "invoice_overdue_14d",
+      invoice_id,
+      { invoice_id, amount },
+      emailOk ? "sent" : "failed",
+    );
+  }
+  
+  return new Response(JSON.stringify({ ok: ownerSmsOk && emailOk }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+});

--- a/supabase/functions/invoice-overdue-7d/index.ts
+++ b/supabase/functions/invoice-overdue-7d/index.ts
@@ -1,0 +1,27 @@
+import { sendEmail, logNotification, shouldSendNotification } from "../_shared/notifications.ts";
+
+// Event: Invoice overdue 7 days
+// Triggered by cron (daily)
+// Sends: Customer email reminder
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== "POST") return new Response("Method not allowed", { status: 405 });
+  
+  const { invoice_id, customer_email, customer_name, amount, due_date } = await req.json();
+
+  if (!(await shouldSendNotification("customer", "email", "invoice_overdue_7d", invoice_id))) {
+    return new Response(JSON.stringify({ ok: true, skipped: "Duplicate invoice_overdue_7d" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  
+  const html = `<h2>Payment Reminder</h2><p>Dear ${customer_name},</p><p>This is a friendly reminder that invoice #${invoice_id?.slice(0,8)} for $${amount} was due on ${due_date}.</p><p>Please submit payment at your earliest convenience.</p><p>Questions? Call us at (504) 875-8079.</p><p>Thank you,<br>Xcellent1 Lawn Care</p>`;
+  const emailOk = await sendEmail(customer_email, "Payment Reminder - Xcellent1 Lawn Care", html);
+  await logNotification("customer", undefined, "email", "invoice_overdue_7d", invoice_id, { invoice_id, amount }, emailOk ? "sent" : "failed");
+  
+  return new Response(JSON.stringify({ ok: emailOk }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+});

--- a/supabase/functions/job-complete/index.ts
+++ b/supabase/functions/job-complete/index.ts
@@ -1,0 +1,87 @@
+import {
+  sendSMS,
+  sendEmail,
+  logNotification,
+  NotificationEvent,
+  shouldSendNotification,
+} from "../_shared/notifications.ts";
+
+// Event: Job marked complete
+// Triggers: Owner SMS + dashboard, Customer SMS + Email (completion + photo)
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== "POST") return new Response("Method not allowed", { status: 405 });
+  
+  const event: NotificationEvent = await req.json();
+  const { job_id, payload } = event;
+  
+  const ownerPhone = Deno.env.get("OWNER_PHONE") || "";
+  const customerPhone = (payload.customer_phone as string) || "";
+  const customerEmail = (payload.customer_email as string) || "";
+  const jobAddress = (payload.address as string) || "";
+  const photoUrl = (payload.completion_photo_url as string) || "";
+  
+  const errors: string[] = [];
+  
+  // Owner SMS (deduped by job_id)
+  if (await shouldSendNotification("owner", "sms", "job_complete", job_id)) {
+    const ownerSmsOk = await sendSMS(
+      ownerPhone,
+      `✅ Job #${job_id?.slice(0, 8)} complete at ${jobAddress}. View photos in dashboard.`,
+    );
+    if (!ownerSmsOk) errors.push("Owner SMS failed");
+    await logNotification(
+      "owner",
+      undefined,
+      "sms",
+      "job_complete",
+      job_id,
+      { job_id },
+      ownerSmsOk ? "sent" : "failed",
+    );
+  }
+  
+  // Customer SMS (deduped by job_id)
+  if (customerPhone && await shouldSendNotification("customer", "sms", "job_complete", job_id)) {
+    const custSmsOk = await sendSMS(
+      customerPhone,
+      `✅ Your lawn service at ${jobAddress} is complete! Thank you for choosing Xcellent1 Lawn Care.`,
+    );
+    if (!custSmsOk) errors.push("Customer SMS failed");
+    await logNotification(
+      "customer",
+      undefined,
+      "sms",
+      "job_complete",
+      job_id,
+      { job_id },
+      custSmsOk ? "sent" : "failed",
+    );
+  }
+  
+  // Customer Email with photo (deduped by job_id)
+  if (customerEmail && await shouldSendNotification("customer", "email", "job_complete", job_id)) {
+    const html =
+      `<h2>Your Lawn Service is Complete!</h2><p>Thank you for choosing Xcellent1 Lawn Care.</p>${photoUrl ? `<p><img src="${photoUrl}" alt="After photo" style="max-width:400px"></p>` : ""}<p>Rate your service: <a href="https://g.page/r/CZbYqiFFQ57SEBM/review">Leave a Review</a></p>`;
+    const emailOk = await sendEmail(
+      customerEmail,
+      "Your Lawn Service is Complete!",
+      html,
+    );
+    if (!emailOk) errors.push("Customer email failed");
+    await logNotification(
+      "customer",
+      undefined,
+      "email",
+      "job_complete",
+      job_id,
+      { job_id },
+      emailOk ? "sent" : "failed",
+    );
+  }
+  
+  return new Response(JSON.stringify({ ok: errors.length === 0, errors }), {
+    status: errors.length === 0 ? 200 : 207,
+    headers: { "Content-Type": "application/json" },
+  });
+});

--- a/supabase/functions/job-reminder-24h/index.ts
+++ b/supabase/functions/job-reminder-24h/index.ts
@@ -1,0 +1,59 @@
+import { sendSMS, logNotification, shouldSendNotification } from "../_shared/notifications.ts";
+
+// Event: 24hrs before job — Crew reminder + Customer reminder
+// Triggered by cron (daily at 6pm CT)
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== "POST") return new Response("Method not allowed", { status: 405 });
+  
+  const { jobs } = await req.json();
+  
+  if (!Array.isArray(jobs)) {
+    return new Response(JSON.stringify({ ok: false, error: "Expected jobs array" }), { status: 400 });
+  }
+  
+  const results: { job_id: string; crew_sms: boolean; customer_sms: boolean }[] = [];
+  
+  for (const job of jobs) {
+    let crewSmsOk = false;
+    if (await shouldSendNotification("crew", "sms", "job_reminder_24h", job.id)) {
+      crewSmsOk = await sendSMS(
+        job.crew_phone,
+        `⏰ Reminder: Job tomorrow at ${job.scheduled_time} - ${job.address}`,
+      );
+      await logNotification(
+        "crew",
+        undefined,
+        "sms",
+        "job_reminder_24h",
+        job.id,
+        { job_id: job.id },
+        crewSmsOk ? "sent" : "failed",
+      );
+    }
+    
+    let custSmsOk = false;
+    if (await shouldSendNotification("customer", "sms", "job_reminder_24h", job.id)) {
+      custSmsOk = await sendSMS(
+        job.customer_phone,
+        `⏰ Reminder: Your lawn service is tomorrow at ${job.scheduled_time}. Address: ${job.address}`,
+      );
+      await logNotification(
+        "customer",
+        undefined,
+        "sms",
+        "job_reminder_24h",
+        job.id,
+        { job_id: job.id },
+        custSmsOk ? "sent" : "failed",
+      );
+    }
+    
+    results.push({ job_id: job.id, crew_sms: crewSmsOk, customer_sms: custSmsOk });
+  }
+  
+  return new Response(JSON.stringify({ ok: true, results }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+});

--- a/supabase/functions/job-scheduled/index.ts
+++ b/supabase/functions/job-scheduled/index.ts
@@ -1,0 +1,88 @@
+import {
+  sendSMS,
+  sendEmail,
+  logNotification,
+  NotificationEvent,
+  shouldSendNotification,
+} from "../_shared/notifications.ts";
+
+// Event: Job scheduled
+// Triggers: Crew SMS, Customer SMS + Email (confirmation)
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== "POST") return new Response("Method not allowed", { status: 405 });
+  
+  const event: NotificationEvent = await req.json();
+  const { job_id, payload } = event;
+  
+  const crewPhone = (payload.crew_phone as string) || "";
+  const customerPhone = (payload.customer_phone as string) || "";
+  const customerEmail = (payload.customer_email as string) || "";
+  const jobDate = (payload.scheduled_date as string) || "";
+  const jobAddress = (payload.address as string) || "";
+  const jobTime = (payload.scheduled_time as string) || "8:00 AM";
+  
+  const errors: string[] = [];
+  
+  // Crew SMS (deduped by job_id)
+  if (crewPhone && await shouldSendNotification("crew", "sms", "job_scheduled", job_id)) {
+    const crewSmsOk = await sendSMS(
+      crewPhone,
+      `📋 New job scheduled: ${jobDate} at ${jobTime} - ${jobAddress}`,
+    );
+    if (!crewSmsOk) errors.push("Crew SMS failed");
+    await logNotification(
+      "crew",
+      undefined,
+      "sms",
+      "job_scheduled",
+      job_id,
+      { job_id },
+      crewSmsOk ? "sent" : "failed",
+    );
+  }
+  
+  // Customer SMS (deduped by job_id)
+  if (customerPhone && await shouldSendNotification("customer", "sms", "job_scheduled", job_id)) {
+    const custSmsOk = await sendSMS(
+      customerPhone,
+      `📋 Your lawn service is confirmed for ${jobDate} at ${jobTime}. Address: ${jobAddress}`,
+    );
+    if (!custSmsOk) errors.push("Customer SMS failed");
+    await logNotification(
+      "customer",
+      undefined,
+      "sms",
+      "job_scheduled",
+      job_id,
+      { job_id },
+      custSmsOk ? "sent" : "failed",
+    );
+  }
+  
+  // Customer Email (deduped by job_id)
+  if (customerEmail && await shouldSendNotification("customer", "email", "job_scheduled", job_id)) {
+    const html =
+      `<h2>Service Confirmation</h2><p>Your lawn service is confirmed:</p><ul><li>Date: ${jobDate}</li><li>Time: ${jobTime}</li><li>Address: ${jobAddress}</li></ul><p>Questions? Call us at (504) 875-8079</p>`;
+    const emailOk = await sendEmail(
+      customerEmail,
+      "Service Confirmed - Xcellent1 Lawn Care",
+      html,
+    );
+    if (!emailOk) errors.push("Customer email failed");
+    await logNotification(
+      "customer",
+      undefined,
+      "email",
+      "job_scheduled",
+      job_id,
+      { job_id },
+      emailOk ? "sent" : "failed",
+    );
+  }
+  
+  return new Response(JSON.stringify({ ok: errors.length === 0, errors }), {
+    status: errors.length === 0 ? 200 : 207,
+    headers: { "Content-Type": "application/json" },
+  });
+});

--- a/supabase/functions/lead-alert/index.ts
+++ b/supabase/functions/lead-alert/index.ts
@@ -1,0 +1,55 @@
+import {
+  sendSMS,
+  logNotification,
+  NotificationEvent,
+  shouldSendNotification,
+} from "../_shared/notifications.ts";
+
+// Event: New quote request submitted (high-score lead)
+// Triggers: Owner SMS if lead score > 70
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== "POST") return new Response("Method not allowed", { status: 405 });
+  
+  const event: NotificationEvent = await req.json();
+  const { lead_id, payload } = event;
+  
+  const ownerPhone = Deno.env.get("OWNER_PHONE") || "";
+  const leadName = (payload.name as string) || "New Lead";
+  const leadPhone = (payload.phone as string) || "";
+  const leadScore = (payload.score as number) || 0;
+  
+  // Only alert owner if lead score > 70
+  if (leadScore <= 70) {
+    return new Response(JSON.stringify({ ok: true, skipped: "Low score lead, queued for daily digest" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  
+  if (!(await shouldSendNotification("owner", "sms", "lead_alert", lead_id))) {
+    return new Response(JSON.stringify({ ok: true, skipped: "Duplicate lead_alert" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const smsOk = await sendSMS(
+    ownerPhone,
+    `🔥 High-score lead: ${leadName} (${leadScore}/100). Phone: ${leadPhone}`,
+  );
+  await logNotification(
+    "owner",
+    undefined,
+    "sms",
+    "lead_alert",
+    lead_id,
+    { lead_id, score: leadScore },
+    smsOk ? "sent" : "failed",
+  );
+  
+  return new Response(JSON.stringify({ ok: smsOk }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+});

--- a/supabase/functions/review-request-3d/index.ts
+++ b/supabase/functions/review-request-3d/index.ts
@@ -1,0 +1,41 @@
+import { sendSMS, logNotification, shouldSendNotification } from "../_shared/notifications.ts";
+
+// Event: 3 days post-completion — Customer review request
+// Triggered by cron (daily)
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== "POST") return new Response("Method not allowed", { status: 405 });
+  
+  const { jobs } = await req.json();
+  
+  if (!Array.isArray(jobs)) {
+    return new Response(JSON.stringify({ ok: false, error: "Expected jobs array" }), { status: 400 });
+  }
+  
+  const results: { job_id: string; sms_sent: boolean }[] = [];
+  
+  for (const job of jobs) {
+    let smsOk = false;
+    if (await shouldSendNotification("customer", "sms", "review_request_3d", job.id)) {
+      smsOk = await sendSMS(
+        job.customer_phone,
+        `Hi ${job.customer_name}! How was your lawn service? We'd love your feedback: https://g.page/r/CZbYqiFFQ57SEBM/review Thank you! — Xcellent1 Lawn Care`,
+      );
+      await logNotification(
+        "customer",
+        undefined,
+        "sms",
+        "review_request_3d",
+        job.id,
+        { job_id: job.id },
+        smsOk ? "sent" : "failed",
+      );
+    }
+    results.push({ job_id: job.id, sms_sent: smsOk });
+  }
+  
+  return new Response(JSON.stringify({ ok: true, results }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+});

--- a/supabase/functions/worker-application/index.ts
+++ b/supabase/functions/worker-application/index.ts
@@ -1,0 +1,49 @@
+import {
+  sendSMS,
+  logNotification,
+  NotificationEvent,
+  shouldSendNotification,
+} from "../_shared/notifications.ts";
+
+// Event: New worker application
+// Triggers: Owner SMS
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== "POST") return new Response("Method not allowed", { status: 405 });
+  
+  const event: NotificationEvent = await req.json();
+  const { payload } = event;
+  
+  const ownerPhone = Deno.env.get("OWNER_PHONE") || "";
+  const applicantName = (payload.name as string) || "New Applicant";
+  const applicantPhone = (payload.phone as string) || "";
+  
+  // Prefer a stable ref for dedupe; fall back to phone if no id present.
+  const refId = (payload.id as string) || applicantPhone || undefined;
+
+  if (!(await shouldSendNotification("owner", "sms", "worker_application", refId))) {
+    return new Response(JSON.stringify({ ok: true, skipped: "Duplicate worker_application" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const smsOk = await sendSMS(
+    ownerPhone,
+    `👷 New worker application: ${applicantName}. Phone: ${applicantPhone}`,
+  );
+  await logNotification(
+    "owner",
+    undefined,
+    "sms",
+    "worker_application",
+    refId,
+    { applicant_name: applicantName },
+    smsOk ? "sent" : "failed",
+  );
+  
+  return new Response(JSON.stringify({ ok: smsOk }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+});

--- a/supabase/migrations/001_webapp_platform.sql
+++ b/supabase/migrations/001_webapp_platform.sql
@@ -1,0 +1,144 @@
+-- Webapp Platform Realize Spec — Module 1 + 3
+-- Linked Issue: #27
+-- Date: 2026-04-01
+-- Gate 2: wiki/hitl/realize-webapp-platform-2026-04-01.md
+
+-- =============================================
+-- New Tables
+-- =============================================
+
+CREATE TABLE IF NOT EXISTS worker_applications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  auth_user_id UUID,
+  name TEXT NOT NULL,
+  phone TEXT NOT NULL,
+  email TEXT,
+  equipment_owned JSONB DEFAULT '[]',
+  availability JSONB DEFAULT '{}',
+  service_areas TEXT[] DEFAULT '{}',
+  status TEXT DEFAULT 'pending' CHECK (status IN ('pending', 'approved', 'rejected')),
+  applied_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS performance_scores (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  worker_id UUID REFERENCES users(id),
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  jobs_completed INT DEFAULT 0,
+  jobs_on_time INT DEFAULT 0,
+  quality_score DECIMAL(4,2),
+  status TEXT DEFAULT 'green' CHECK (status IN ('green', 'yellow', 'red')),
+  calculated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS notifications_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  recipient_type TEXT CHECK (recipient_type IN ('owner', 'crew', 'customer')),
+  recipient_id UUID,
+  channel TEXT CHECK (channel IN ('sms', 'email', 'push')),
+  event_type TEXT NOT NULL,
+  ref_id TEXT,
+  payload JSONB DEFAULT '{}',
+  sent_at TIMESTAMPTZ DEFAULT NOW(),
+  status TEXT DEFAULT 'sent' CHECK (status IN ('sent', 'failed', 'bounced'))
+);
+
+-- =============================================
+-- Extend existing jobs table
+-- =============================================
+
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS completion_photo_url TEXT;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS crew_en_route_at TIMESTAMPTZ;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS started_at TIMESTAMPTZ;
+
+-- =============================================
+-- Enable Supabase Realtime on key tables
+-- =============================================
+
+-- Enable realtime for jobs table
+DO $$
+BEGIN
+  -- jobs
+  IF to_regclass('public.jobs') IS NOT NULL THEN
+    BEGIN
+      ALTER PUBLICATION supabase_realtime ADD TABLE public.jobs;
+    EXCEPTION WHEN duplicate_object THEN
+      -- already added
+    END;
+  END IF;
+
+  -- leads (only if the table exists in this project)
+  IF to_regclass('public.leads') IS NOT NULL THEN
+    BEGIN
+      ALTER PUBLICATION supabase_realtime ADD TABLE public.leads;
+    EXCEPTION WHEN duplicate_object THEN
+      -- already added
+    END;
+  END IF;
+END;
+$$;
+
+-- =============================================
+-- Indexes for performance
+-- =============================================
+
+CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status);
+CREATE INDEX IF NOT EXISTS idx_performance_scores_worker ON performance_scores(worker_id, period_start);
+CREATE INDEX IF NOT EXISTS idx_notifications_log_event ON notifications_log(event_type, sent_at);
+CREATE INDEX IF NOT EXISTS idx_worker_applications_status ON worker_applications(status);
+
+-- Dedupe: avoid sending same notification twice for same ref
+CREATE UNIQUE INDEX IF NOT EXISTS idx_notifications_log_dedupe
+  ON notifications_log(event_type, channel, recipient_type, ref_id)
+  WHERE ref_id IS NOT NULL;
+
+-- =============================================
+-- RLS Policies
+-- =============================================
+
+-- Worker applications: owner can view all, applicants can view own
+ALTER TABLE worker_applications ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "owner_can_view_all_applications" ON worker_applications
+  FOR SELECT USING (
+    COALESCE(auth.jwt() -> 'user_metadata' ->> 'role', auth.jwt() ->> 'role') = 'owner'
+  );
+
+CREATE POLICY "applicant_can_view_own" ON worker_applications
+  FOR SELECT USING (auth.uid() = auth_user_id);
+
+CREATE POLICY "public_can_insert_worker_applications" ON worker_applications
+  FOR INSERT WITH CHECK (true);
+
+CREATE POLICY "owner_can_update_applications" ON worker_applications
+  FOR UPDATE USING (
+    COALESCE(auth.jwt() -> 'user_metadata' ->> 'role', auth.jwt() ->> 'role') = 'owner'
+  );
+
+-- Performance scores: owner can view all, crew can view own
+ALTER TABLE performance_scores ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "owner_can_view_all_scores" ON performance_scores
+  FOR SELECT USING (
+    COALESCE(auth.jwt() -> 'user_metadata' ->> 'role', auth.jwt() ->> 'role') = 'owner'
+  );
+
+CREATE POLICY "crew_can_view_own_scores" ON performance_scores
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM users u
+      WHERE u.id = performance_scores.worker_id
+        AND u.auth_user_id = auth.uid()
+        AND u.role = 'crew'
+    )
+  );
+
+-- Notifications log: owner can view all
+ALTER TABLE notifications_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "owner_can_view_notifications" ON notifications_log
+  FOR SELECT USING (
+    COALESCE(auth.jwt() -> 'user_metadata' ->> 'role', auth.jwt() ->> 'role') = 'owner'
+  );

--- a/tests/crew/performance.test.ts
+++ b/tests/crew/performance.test.ts
@@ -1,0 +1,22 @@
+import { generateTestToken, createAuthHeaders } from "../support/helpers/auth-helper.ts";
+import { databaseTest } from "../test-config.ts";
+
+const BASE_URL = Deno.env.get("BASE_URL") || "http://localhost:8000";
+
+databaseTest("crew performance self-view returns ok + status", async () => {
+  // This test assumes the test DB has a crew user id that exists in public.users.
+  // The existing test harness already provisions users for other endpoints.
+  const crewUserId = "crew-test-user";
+  const { token } = await generateTestToken("crew", crewUserId);
+
+  const res = await fetch(`${BASE_URL}/api/crew/performance`, {
+    method: "GET",
+    headers: createAuthHeaders(token),
+  });
+
+  if (res.status !== 200) throw new Error(`Unexpected status: ${res.status}`);
+
+  const json = await res.json();
+  if (json.ok !== true) throw new Error("Expected ok=true");
+  if (typeof json.status !== "string") throw new Error("Expected status string");
+});

--- a/tests/dashboard/realtime.test.ts
+++ b/tests/dashboard/realtime.test.ts
@@ -1,0 +1,9 @@
+import { assert } from "https://deno.land/std@0.203.0/testing/asserts.ts";
+
+// Realize Spec (#27): Owner dashboard reflects job updates within 3s.
+// This is a placeholder contract test. End-to-end realtime validation requires
+// a running Supabase project with realtime enabled on `jobs`.
+
+Deno.test("dashboard/realtime test exists (stub)", () => {
+  assert(true);
+});

--- a/tests/db_schema_test.ts
+++ b/tests/db_schema_test.ts
@@ -30,3 +30,21 @@ Deno.test("DB migrations exist and include core tables", async () => {
     "owner_invitations table not found in migration",
   );
 });
+
+Deno.test("Primary schema includes webapp platform tables", async () => {
+  const schemaPath = "./db/schema.sql";
+  const txt = await Deno.readTextFile(schemaPath);
+
+  assert(
+    txt.includes("CREATE TABLE IF NOT EXISTS worker_applications"),
+    "worker_applications table not found in db/schema.sql",
+  );
+  assert(
+    txt.includes("CREATE TABLE IF NOT EXISTS performance_scores"),
+    "performance_scores table not found in db/schema.sql",
+  );
+  assert(
+    txt.includes("CREATE TABLE IF NOT EXISTS notifications_log"),
+    "notifications_log table not found in db/schema.sql",
+  );
+});

--- a/tests/notifications/crew-en-route.test.ts
+++ b/tests/notifications/crew-en-route.test.ts
@@ -1,0 +1,8 @@
+import { assert } from "https://deno.land/std@0.203.0/testing/asserts.ts";
+
+// Realize Spec (#27): crew en route -> customer SMS (ETA).
+// Stub only.
+
+Deno.test("notifications/crew-en-route exists (stub)", () => {
+  assert(true);
+});

--- a/tests/notifications/crew-red-status.test.ts
+++ b/tests/notifications/crew-red-status.test.ts
@@ -1,0 +1,8 @@
+import { assert } from "https://deno.land/std@0.203.0/testing/asserts.ts";
+
+// Realize Spec (#27): crew red status -> owner SMS alert + crew self-view update.
+// Stub only.
+
+Deno.test("notifications/crew-red-status exists (stub)", () => {
+  assert(true);
+});

--- a/tests/notifications/invoice-overdue-14d.test.ts
+++ b/tests/notifications/invoice-overdue-14d.test.ts
@@ -1,0 +1,8 @@
+import { assert } from "https://deno.land/std@0.203.0/testing/asserts.ts";
+
+// Realize Spec (#27): invoice overdue 14d -> owner SMS escalation + customer email.
+// Stub only.
+
+Deno.test("notifications/invoice-overdue-14d exists (stub)", () => {
+  assert(true);
+});

--- a/tests/notifications/invoice-overdue-7d.test.ts
+++ b/tests/notifications/invoice-overdue-7d.test.ts
@@ -1,0 +1,8 @@
+import { assert } from "https://deno.land/std@0.203.0/testing/asserts.ts";
+
+// Realize Spec (#27): invoice overdue 7d -> customer email reminder.
+// Stub only.
+
+Deno.test("notifications/invoice-overdue-7d exists (stub)", () => {
+  assert(true);
+});

--- a/tests/notifications/job-complete.test.ts
+++ b/tests/notifications/job-complete.test.ts
@@ -1,0 +1,9 @@
+import { assert } from "https://deno.land/std@0.203.0/testing/asserts.ts";
+
+// Realize Spec (#27): job marked complete -> owner SMS + customer SMS/email.
+// This is a contract stub: real sending is env-dependent and should be covered
+// in an integration environment with Supabase + Twilio/SendGrid configured.
+
+Deno.test("notifications/job-complete exists (stub)", () => {
+  assert(true);
+});

--- a/tests/notifications/job-reminder-24h.test.ts
+++ b/tests/notifications/job-reminder-24h.test.ts
@@ -1,0 +1,8 @@
+import { assert } from "https://deno.land/std@0.203.0/testing/asserts.ts";
+
+// Realize Spec (#27): 24h before job -> crew + customer SMS reminder (cron).
+// Stub only.
+
+Deno.test("notifications/job-reminder-24h exists (stub)", () => {
+  assert(true);
+});

--- a/tests/notifications/job-scheduled.test.ts
+++ b/tests/notifications/job-scheduled.test.ts
@@ -1,0 +1,8 @@
+import { assert } from "https://deno.land/std@0.203.0/testing/asserts.ts";
+
+// Realize Spec (#27): job scheduled -> crew SMS + customer SMS/email.
+// Stub only.
+
+Deno.test("notifications/job-scheduled exists (stub)", () => {
+  assert(true);
+});

--- a/tests/notifications/lead-alert.test.ts
+++ b/tests/notifications/lead-alert.test.ts
@@ -1,0 +1,8 @@
+import { assert } from "https://deno.land/std@0.203.0/testing/asserts.ts";
+
+// Realize Spec (#27): high-score lead -> owner SMS (score > 70).
+// Stub only.
+
+Deno.test("notifications/lead-alert exists (stub)", () => {
+  assert(true);
+});

--- a/tests/notifications/review-request-3d.test.ts
+++ b/tests/notifications/review-request-3d.test.ts
@@ -1,0 +1,8 @@
+import { assert } from "https://deno.land/std@0.203.0/testing/asserts.ts";
+
+// Realize Spec (#27): 3 days post-completion -> customer SMS review request (cron).
+// Stub only.
+
+Deno.test("notifications/review-request-3d exists (stub)", () => {
+  assert(true);
+});

--- a/tests/notifications/worker-application.test.ts
+++ b/tests/notifications/worker-application.test.ts
@@ -1,0 +1,8 @@
+import { assert } from "https://deno.land/std@0.203.0/testing/asserts.ts";
+
+// Realize Spec (#27): new worker application -> owner SMS.
+// Stub only.
+
+Deno.test("notifications/worker-application exists (stub)", () => {
+  assert(true);
+});

--- a/web/static/crew.html
+++ b/web/static/crew.html
@@ -39,6 +39,16 @@
         Logout
       </button>
     </div>
+    <div class="route-summary" style="margin-top: 0.75rem">
+      <div class="route-summary-item">
+        <span>🟢</span>
+        <span><strong id="crew-performance-status">Loading</strong></span>
+      </div>
+      <div class="route-summary-item">
+        <span>📅</span>
+        <span id="performance-period">This period</span>
+      </div>
+    </div>
     <div class="route-summary">
       <div class="route-summary-item">
         <span>📅</span>
@@ -128,7 +138,9 @@
   </script>
   <script>
     // Crew Dashboard Logic
-    const CREW_ID = window.crewProfile?.id || "crew_marcus_01"; // Get from auth
+    function getCrewId() {
+      return window.crewProfile?.id || "crew_marcus_01";
+    }
     let currentJob = null;
     let photoType = "before";
     let capturedPhoto = null;
@@ -142,7 +154,7 @@
           throw new Error("No authentication token");
         }
 
-        const response = await fetch(`/api/crew/${CREW_ID}/jobs`, {
+        const response = await fetch(`/api/crew/${getCrewId()}/jobs`, {
           headers: {
             Authorization: `Bearer ${token}`,
           },
@@ -170,8 +182,53 @@
       }
     }
 
+    async function fetchCrewPerformance() {
+      try {
+        const token = window.supabaseSession?.access_token;
+        if (!token) throw new Error("No authentication token");
+
+        const response = await fetch(`/api/crew/performance`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        if (!response.ok) throw new Error(`API error: ${response.status}`);
+        const data = await response.json();
+        if (!data.ok) throw new Error(data.error || "Failed to fetch performance");
+        return data;
+      } catch (err) {
+        console.error("Failed to fetch crew performance:", err);
+        return null;
+      }
+    }
+
+    function renderCrewPerformance(perf) {
+      const statusEl = document.getElementById("crew-performance-status");
+      const periodEl = document.getElementById("performance-period");
+      if (!statusEl || !periodEl) return;
+
+      if (!perf) {
+        statusEl.textContent = "Unknown";
+        periodEl.textContent = "";
+        return;
+      }
+
+      const status = (perf.status || "green").toString().toLowerCase();
+      const icon = status === "red" ? "🔴" : status === "yellow" ? "🟡" : "🟢";
+      statusEl.textContent = `${icon} ${status.toUpperCase()}`;
+
+      const ps = perf.period_start;
+      const pe = perf.period_end;
+      periodEl.textContent = ps && pe ? `${ps} to ${pe}` : "";
+    }
+
     // Load crew jobs
     async function loadCrewJobs() {
+      // Fetch and render performance status (self-view)
+      const perf = await fetchCrewPerformance();
+      renderCrewPerformance(perf);
+
       // Fetch jobs from API
       const apiJobs = await fetchCrewJobs();
 
@@ -412,11 +469,35 @@
       });
     });
 
-    // Initial load
-    loadCrewJobs();
+    async function waitForCrewAuth(maxWaitMs = 10000) {
+      const start = Date.now();
+      while (Date.now() - start < maxWaitMs) {
+        if (window.supabaseSession?.access_token && window.crewProfile?.id) return true;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      return false;
+    }
 
-    // Refresh every 5 minutes
-    setInterval(loadCrewJobs, 300000);
+    // Initial load
+    (async () => {
+      const ready = await waitForCrewAuth();
+      if (!ready) {
+        showMessage(
+          "crew-status",
+          "⚠️ Authentication not ready. Please refresh the page.",
+          "warning",
+          5000,
+        );
+        return;
+      }
+
+      loadCrewJobs();
+
+      // Refresh every 5 minutes
+      setInterval(loadCrewJobs, 300000);
+    })();
+
+    // Note: interval started after auth readiness
   </script>
 </body>
 

--- a/web/static/owner.html
+++ b/web/static/owner.html
@@ -821,11 +821,45 @@
         .join("");
     }
 
-    // Initial load
-    loadOwnerDashboard();
+    // Wait for auth to populate supabase session/client before doing any work.
+    async function waitForOwnerAuth(maxWaitMs = 10000) {
+      const start = Date.now();
+      while (Date.now() - start < maxWaitMs) {
+        if (window.supabaseSession?.access_token && window.supabaseClient) return true;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      return false;
+    }
 
-    // Auto-refresh every 60 seconds
-    setInterval(loadOwnerDashboard, 60000);
+    (async () => {
+      const ready = await waitForOwnerAuth();
+      if (!ready) {
+        console.warn("Owner auth not ready; skipping realtime init");
+        return;
+      }
+
+      // Initial load
+      loadOwnerDashboard();
+
+      // Auto-refresh every 60 seconds
+      setInterval(loadOwnerDashboard, 60000);
+
+      // Supabase Realtime WebSocket for live job updates
+      window.supabaseClient
+        .channel("owner-jobs-realtime")
+        .on(
+          "postgres_changes",
+          { event: "UPDATE", schema: "public", table: "jobs" },
+          (_payload) => {
+            loadOwnerDashboard();
+          },
+        )
+        // Note: leads table exists in some DB schemas but not all environments.
+        // Keep job updates realtime; leads insert can be added back once confirmed.
+        .subscribe((status) => {
+          console.log("Realtime subscription status:", status);
+        });
+    })();
   </script>
 </body>
 


### PR DESCRIPTION
## Summary
- Add Supabase edge-function stubs for the 10 realize event types (Twilio/SendGrid wiring + notifications_log-backed dedupe).
- Add migration for Issue #27 schema additions (worker_applications, performance_scores, notifications_log) and realtime publication entries.
- Add crew performance self-view endpoint and UI widget; gate crew/owner dashboards on auth readiness and enable realtime jobs UPDATE on owner dashboard.
- Add initial test stubs for notifications + dashboard realtime and a schema presence check.

## Notes
- Deno tooling is not available in this environment, so tests/typecheck were not executed here.
- Outbox/trigger dispatcher wiring is not included yet; this PR focuses on the platform stubs and UI for Module 1 + 3.

## Risk
- `db/schema.sql` now includes a guarded `supabase_realtime` publication block (no-op if publication absent).