### PR TITLE
Blog overhaul: comprehensive expansion, index page, internal linking

### DIFF
--- a/web/static/blog-fertilizing-guide.html
+++ b/web/static/blog-fertilizing-guide.html
@@ -1,0 +1,709 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Complete Lawn Fertilizing Guide for Louisiana | Xcellent1 Lawn Care Blog</title>
+    <meta
+      name="description"
+      content="Master lawn fertilizing for South Louisiana. Soil testing for clay/silt soils, N-P-K breakdown, month-by-month calendar, organic options, and common mistakes. Expert tips for the River Parishes."
+    />
+    <!-- Open Graph -->
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://xcellent1lawncare.com/blog-fertilizing-guide" />
+    <meta
+      property="og:title"
+      content="Complete Lawn Fertilizing Guide for Louisiana"
+    />
+    <meta
+      property="og:description"
+      content="Master lawn fertilizing for South Louisiana. Soil testing, N-P-K breakdown, month-by-month calendar, organic options, and common mistakes."
+    />
+    <meta property="og:image" content="https://xcellent1lawncare.com/images/product-fertilizer.jpg" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="article:published_time" content="2025-11-22" />
+    <meta property="og:site_name" content="Xcellent1 Lawn Care" />
+    <meta property="og:locale" content="en_US" />
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="Complete Lawn Fertilizing Guide for Louisiana"
+    />
+    <meta
+      name="twitter:description"
+      content="Master lawn fertilizing for South Louisiana. Soil testing, N-P-K breakdown, month-by-month calendar, organic options, and common mistakes from local pros."
+    />
+    <meta name="twitter:image" content="https://xcellent1lawncare.com/images/product-fertilizer.jpg" />
+    <!-- Canonical -->
+    <link rel="canonical" href="https://xcellent1lawncare.com/blog-fertilizing-guide" />
+    <link rel="icon" type="image/png" sizes="32x32" href="images/favicon.ico" />
+    <link rel="stylesheet" href="styles.clean.css" />
+    <meta name="theme-color" content="#3b832a" />
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "Complete Lawn Fertilizing Guide for Louisiana",
+        "description": "Master lawn fertilizing for South Louisiana. Soil testing, N-P-K breakdown, month-by-month calendar, organic options, and common mistakes.",
+        "author": { "@type": "Organization", "name": "Xcellent1 Lawn Care" },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Xcellent1 Lawn Care"
+        },
+        "datePublished": "2025-11-22",
+        "mainEntityOfPage": {
+          "@id": "https://xcellent1lawncare.com/blog-fertilizing-guide"
+        }
+      }
+    </script>
+    <style>
+      .blog-hero {
+        background:
+          linear-gradient(
+            135deg,
+            rgba(59, 131, 42, 0.92),
+            rgba(19, 63, 28, 0.96)
+          ),
+          url("images/product-fertilizer.jpg") center/cover;
+        padding: 5rem 1rem;
+        text-align: center;
+        color: #fff;
+      }
+      .blog-hero h1 {
+        font-size: clamp(2rem, 4vw, 3.2rem);
+        margin-bottom: 0.75rem;
+        font-weight: 800;
+        text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+      }
+      .blog-hero .meta {
+        font-size: 0.95rem;
+        opacity: 0.95;
+        display: flex;
+        justify-content: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+      .reading-time {
+        background: rgba(255, 255, 255, 0.2);
+        padding: 0.25rem 0.75rem;
+        border-radius: 20px;
+        font-size: 0.85rem;
+      }
+      .blog-container {
+        max-width: 860px;
+        margin: -3rem auto 0;
+        padding: 0 1rem 2rem;
+        position: relative;
+        z-index: 10;
+      }
+      .blog-content {
+        background: #fff;
+        border-radius: 16px;
+        padding: 2.5rem;
+        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
+      }
+      .blog-content > p:first-of-type {
+        font-size: 1.15rem;
+        color: #4b5563;
+        line-height: 1.8;
+      }
+      .blog-content h2 {
+        color: #166534;
+        margin: 2.5rem 0 1rem;
+        font-size: 1.6rem;
+        position: relative;
+        padding-bottom: 0.5rem;
+      }
+      .blog-content h2::after {
+        content: "";
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 60px;
+        height: 3px;
+        background: linear-gradient(90deg, #22c55e, #3b832a);
+        border-radius: 2px;
+      }
+      .blog-content h3 {
+        color: #14532d;
+        margin: 1.75rem 0 0.75rem;
+        font-size: 1.25rem;
+      }
+      .blog-content p, .blog-content li {
+        line-height: 1.8;
+        color: #374151;
+        font-size: 1.02rem;
+      }
+      .blog-content p {
+        margin-bottom: 1rem;
+      }
+      .blog-content ul, .blog-content ol {
+        margin: 0.75rem 0 1.5rem;
+        padding-left: 1.5rem;
+      }
+      .blog-content li {
+        margin-bottom: 0.5rem;
+      }
+      .blog-content strong {
+        color: #1f2937;
+      }
+      .blog-content a {
+        color: #166534;
+        text-decoration: underline;
+        font-weight: 600;
+      }
+      .blog-content a:hover {
+        color: #15803d;
+      }
+      /* calendar table */
+      .calendar-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1.5rem 0;
+        font-size: 0.95rem;
+        border-radius: 12px;
+        overflow: hidden;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+      }
+      .calendar-table thead th {
+        background: linear-gradient(135deg, #166534, #15803d);
+        color: #fff;
+        padding: 0.9rem 0.75rem;
+        text-align: left;
+        font-weight: 700;
+        font-size: 0.95rem;
+      }
+      .calendar-table tbody td {
+        padding: 0.85rem 0.75rem;
+        border-bottom: 1px solid #e5e7eb;
+        vertical-align: top;
+      }
+      .calendar-table tbody tr:nth-child(even) {
+        background: #f0fdf4;
+      }
+      .calendar-table tbody tr:hover {
+        background: #dcfce7;
+      }
+      .calendar-table tbody tr:last-child td {
+        border-bottom: none;
+      }
+      .calendar-table .month-name {
+        font-weight: 700;
+        color: #166534;
+        white-space: nowrap;
+        width: 80px;
+      }
+      .calendar-table .fertilizer-rec {
+        font-weight: 600;
+        color: #14532d;
+      }
+      .calendar-table .tip-icon {
+        color: #059669;
+        margin-right: 0.25rem;
+      }
+      /* tip boxes */
+      .tip-box {
+        background: linear-gradient(145deg, #f0fdf4 0%, #dcfce7 100%);
+        border-left: 4px solid #22c55e;
+        border-radius: 12px;
+        padding: 1.25rem 1.5rem;
+        margin: 1.5rem 0;
+      }
+      .tip-box h4 {
+        color: #166534;
+        margin: 0 0 0.5rem;
+        font-size: 1.05rem;
+      }
+      .tip-box p:last-child {
+        margin-bottom: 0;
+      }
+      .warning-box {
+        background: linear-gradient(145deg, #fef2f2 0%, #fee2e2 100%);
+        border-left: 4px solid #ef4444;
+        border-radius: 12px;
+        padding: 1.25rem 1.5rem;
+        margin: 1.5rem 0;
+      }
+      .warning-box h4 {
+        color: #991b1b;
+        margin: 0 0 0.5rem;
+        font-size: 1.05rem;
+      }
+      .warning-box p:last-child {
+        margin-bottom: 0;
+      }
+      .info-box {
+        background: linear-gradient(145deg, #eff6ff 0%, #dbeafe 100%);
+        border-left: 4px solid #3b82f6;
+        border-radius: 12px;
+        padding: 1.25rem 1.5rem;
+        margin: 1.5rem 0;
+      }
+      .info-box h4 {
+        color: #1e40af;
+        margin: 0 0 0.5rem;
+        font-size: 1.05rem;
+      }
+      .info-box p:last-child {
+        margin-bottom: 0;
+      }
+      /* sign grid for over/under */
+      .sign-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 1.25rem;
+        margin: 1.5rem 0;
+      }
+      .sign-card {
+        border-radius: 12px;
+        padding: 1.5rem;
+        border: 2px solid #e5e7eb;
+      }
+      .sign-card.over {
+        background: linear-gradient(145deg, #fef2f2 0%, #fee2e2 100%);
+        border-color: #fca5a5;
+      }
+      .sign-card.under {
+        background: linear-gradient(145deg, #fffbeb 0%, #fef3c7 100%);
+        border-color: #fcd34d;
+      }
+      .sign-card h4 {
+        margin: 0 0 0.75rem;
+        font-size: 1.1rem;
+      }
+      .sign-card.over h4 {
+        color: #991b1b;
+      }
+      .sign-card.under h4 {
+        color: #92400e;
+      }
+      .sign-card ul {
+        margin: 0;
+        padding-left: 1.25rem;
+      }
+      .sign-card ul li {
+        margin-bottom: 0.4rem;
+        font-size: 0.95rem;
+      }
+      .sign-card .photo-desc {
+        display: block;
+        font-style: italic;
+        font-size: 0.85rem;
+        color: #6b7280;
+        margin-top: 0.75rem;
+        padding-top: 0.75rem;
+        border-top: 1px dashed #d1d5db;
+      }
+      @media (max-width: 640px) {
+        .sign-grid {
+          grid-template-columns: 1fr;
+        }
+        .calendar-table {
+          font-size: 0.85rem;
+        }
+        .blog-content {
+          padding: 1.5rem;
+        }
+        .blog-hero {
+          padding: 3.5rem 1rem 2.5rem;
+        }
+        .blog-hero h1 {
+          font-size: 1.75rem;
+        }
+      }
+      /* restore inherited styles */
+      .cta-section {
+        background: linear-gradient(135deg, #3b832a 0%, #10b981 100%);
+        border-radius: 16px;
+        padding: 2.5rem;
+        text-align: center;
+        margin: 3rem 0 2rem;
+      }
+      .cta-section h3 {
+        color: #fff;
+        margin: 0 0 0.75rem;
+        font-size: 1.75rem;
+      }
+      .cta-section p {
+        color: rgba(255, 255, 255, 0.9);
+        margin: 0 0 1.5rem;
+        font-size: 1.1rem;
+      }
+      .cta-section .btn {
+        background: #fff;
+        color: #10b981;
+        padding: 0.875rem 2.5rem;
+        border-radius: 10px;
+        font-weight: 600;
+        text-decoration: none;
+        display: inline-block;
+        transition: all 0.2s;
+        font-size: 1.05rem;
+      }
+      .cta-section .btn:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+      }
+      .back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-top: 2rem;
+        color: #10b981;
+        text-decoration: none;
+        font-weight: 600;
+        transition: gap 0.2s;
+      }
+      .back-link:hover {
+        gap: 0.75rem;
+      }
+      .blog-footer {
+        background: rgba(1, 39, 20, 0.98);
+        color: #fff;
+        text-align: center;
+        padding: 2.5rem 1rem;
+        margin-top: 3rem;
+      }
+    </style>
+  </head>
+  <body>
+    <nav class="navbar">
+      <div class="navbar-brand">
+        <img
+          src="images/xcellent1-logo-transparent.png"
+          alt="Xcellent1 logo"
+          class="navbar-logo"
+        />
+        <div class="navbar-title">
+          <span class="navbar-name">XCELLENT1</span>
+          <span class="navbar-tagline">LAWN CARE</span>
+        </div>
+      </div>
+      <div class="navbar-links">
+        <a href="home.html" class="navbar-link">Home</a>
+        <a href="shop.html" class="navbar-link">Shop</a>
+        <a href="careers.html" class="navbar-link">Careers</a>
+        <a href="login.html" class="navbar-login">Login</a>
+      </div>
+    </nav>
+
+    <header class="blog-hero">
+      <h1>Complete Lawn Fertilizing Guide for Louisiana</h1>
+      <div class="meta">
+        <span>November 2025</span>
+        <span class="reading-time">12 min read</span>
+        <span>Fertility &middot; River Parishes</span>
+      </div>
+    </header>
+
+    <div class="blog-container">
+      <article class="blog-content">
+        <p>
+          Fertilizing a lawn in South Louisiana is different from anywhere else in the country. Our heavy clay and silt soils, subtropical humidity, and long growing season demand a strategy built on soil science, not guesswork. Getting it right means a thick, deep-rooted lawn that shrugs off disease, drought, and winter dormancy. Getting it wrong wastes money and can actually damage the turf and local waterways.
+        </p>
+        <p>
+          This guide covers everything you need &mdash; from taking a soil sample and understanding N-P-K ratios to a month-by-month calendar tailored to the River Parishes, plus organic alternatives and the most common mistakes we see homeowners make.
+        </p>
+
+        <h2>Why Soil Testing Matters for Louisiana Clay and Silt Soils</h2>
+        <p>
+          Louisiana&rsquo;s alluvial soils &mdash; deposited over millennia by the Mississippi River &mdash; are predominantly clay and silt. They are naturally fertile but unpredictable. Clay holds onto nutrients differently than sandy soil. It can lock up phosphorus and potassium, making them unavailable to grass roots even when they are present in the ground. A soil test is the only reliable way to know what is actually available to your lawn.
+        </p>
+
+        <h3>Target pH: 6.0 to 6.5</h3>
+        <p>
+          Warm-season grasses &mdash; St. Augustine, Bermuda, Zoysia, Centipede &mdash; all perform best when soil pH sits between <strong>6.0 and 6.5</strong>. In that range, essential nutrients like nitrogen, phosphorus, potassium, and micronutrients (iron, manganese, zinc) are most soluble and available to the roots.
+        </p>
+        <p>
+          If your pH is below 6.0, the soil is too acidic. Nutrients like phosphorus and calcium become locked. Below 5.5, aluminum toxicity can actually damage root systems. If pH is above 7.0, iron and manganese become unavailable, causing chlorosis &mdash; the yellowing between leaf veins that weakens the turf and invites disease.
+        </p>
+        <div class="tip-box">
+          <h4>Adjusting pH</h4>
+          <p><strong>Too acidic (pH below 6.0):</strong> Apply pelletized dolomitic lime at the rate your soil test recommends. Fall is the best time to lime because it takes several months to fully react.</p>
+          <p><strong>Too alkaline (pH above 7.0):</strong> Elemental sulfur or ammonium sulfate can lower pH. This is rare in Louisiana &mdash; we are much more likely to need lime.</p>
+        </div>
+
+        <h3>How to Take a Proper Soil Sample</h3>
+        <p>
+          A soil test is only as good as the sample. Follow these steps to get an accurate reading:
+        </p>
+        <ol>
+          <li><strong>Use clean tools.</strong> A stainless steel trowel or soil probe. Avoid galvanized or rusty containers &mdash; trace metals will skew the results.</li>
+          <li><strong>Sample at the right depth.</strong> Push the probe or trowel 4 inches deep. That is the root zone for warm-season turf.</li>
+          <li><strong>Take 10 to 15 subsamples</strong> from different areas of your lawn &mdash; front yard, back yard, side strips. Avoid spots near driveways, gutters, fire ant mounds, or where fertilizer was piled.</li>
+          <li><strong>Mix them together</strong> in a clean plastic bucket. Remove thatch, grass blades, pebbles, and roots.</li>
+          <li><strong>Dry about 1 cup</strong> of the mixed soil on newspaper for 24 hours. Do not heat or bake it.</li>
+          <li><strong>Bag and label</strong> the dried sample in a sealed plastic bag or the test lab&rsquo;s provided container.</li>
+        </ol>
+
+        <h3>Where to Send Your Soil Sample</h3>
+        <p>
+          The <strong>LSU AgCenter Soil Testing &amp; Plant Analysis Lab</strong> is the gold standard for Louisiana lawns. Their standard test covers pH, phosphorus, potassium, calcium, magnesium, sodium, and organic matter &mdash; and they will provide specific lime and fertilizer recommendations for warm-season turf.
+        </p>
+        <div class="info-box">
+          <h4>LSU AgCenter Soil Testing Lab</h4>
+          <p><strong>Location:</strong> 2595A St. Patrick Street, Baton Rouge, LA 70820</p>
+          <p><strong>Phone:</strong> (225) 578-1219</p>
+          <p><strong>Cost:</strong> Approximately $10 per sample for a standard fertility test</p>
+          <p><strong>Turnaround:</strong> 2 to 3 weeks during peak season (spring and fall)</p>
+          <p>Sample submission forms and shipping instructions are available on the LSU AgCenter website. Many local county extension offices in the River Parishes also accept samples and handle shipping for you.</p>
+        </div>
+        <p>
+          You should test your soil every <strong>2 to 3 years</strong> or whenever you notice unexplained poor growth, discoloration, or weed pressure shifts.
+        </p>
+
+        <h2>Complete N-P-K Breakdown for Warm-Season Grasses</h2>
+        <p>
+          Every fertilizer bag shows three numbers separated by dashes, like <strong>15-5-10</strong>. These are the N-P-K ratio: <strong>nitrogen (N)</strong>, <strong>phosphorus (P)</strong>, and <strong>potassium (K)</strong>. Each plays a distinct role in grass health, and Louisiana&rsquo;s conditions make some more important than others.
+        </p>
+
+        <h3>Nitrogen (N) &mdash; Growth and Color</h3>
+        <p>
+          Nitrogen drives leaf growth and gives grass its deep green color. It is the nutrient you will apply most often, but it is also the easiest to misuse.
+        </p>
+        <p>
+          <strong>Slow-release nitrogen</strong> (sulfur-coated urea, polymer-coated urea, methylene urea, or natural organics) releases nutrients gradually over 6 to 12 weeks. This is ideal for Louisiana&rsquo;s warm, wet climate because it provides steady feeding without burning the turf or causing a growth surge that requires mowing every three days.
+        </p>
+        <p>
+          <strong>Quick-release nitrogen</strong> (ammonium nitrate, ammonium sulfate, urea) gives an immediate green-up within 24 to 48 hours. It is useful for correcting a deficiency fast but carries higher risk of leaf burn, disease flare-up, and leaching through our sandy-loam pockets after heavy rain.
+        </p>
+        <div class="tip-box">
+          <h4>Our Recommendation</h4>
+          <p>Use a fertilizer where at least <strong>50% of the nitrogen is slow-release</strong>. For River Parishes lawns, this means feeding the grass steadily through our long growing season without the boom-and-bust cycle of quick-release products.</p>
+        </div>
+
+        <h3>Phosphorus (P) &mdash; Root Development and Establishment</h3>
+        <p>
+          Phosphorus supports root growth, seedling establishment, and energy transfer within the plant. It is most critical when installing <a href="blog-sod-installation-guide.html">new sod</a> or seeding.
+        </p>
+        <p>
+          <strong>Important restriction:</strong> Louisiana regulates phosphorus-containing lawn fertilizers. Many parishes &mdash; including parts of the River Parishes &mdash; restrict phosphorus use to <strong>newly established lawns or when a soil test confirms a deficiency</strong>. This is because phosphorus runoff into waterways feeds algae blooms in the Gulf of Mexico and Lake Pontchartrain.
+        </p>
+        <div class="warning-box">
+          <h4>Phosphorus Rule in Louisiana</h4>
+          <p>Do not apply phosphorus to an established lawn unless your soil test shows you need it. Using a zero-phosphorus formula (like 15-0-15) for maintenance applications is both the law and the right thing for the environment.</p>
+        </div>
+
+        <h3>Potassium (K) &mdash; Root Health and Stress Tolerance</h3>
+        <p>
+          Potassium is the unsung hero of lawn nutrition. It strengthens cell walls, improves drought tolerance, helps the grass resist disease, and hardens it against the Louisiana summer heat. Our clay soils often have adequate potassium reserves, but heavy rain can leach it from sandy pockets.
+        </p>
+        <p>
+          A potassium-rich winterizer (like 5-10-20 or 0-0-22) in the fall helps the lawn store carbohydrates and emerge stronger in spring. Grass with adequate potassium shows better cold tolerance during unexpected winter freezes and recovers faster from foot traffic and heat stress.
+        </p>
+
+        <h2>Month-by-Month Fertilization Calendar for the River Parishes</h2>
+        <p>
+          Timing is everything. Apply too early and the grass is still semi-dormant &mdash; the nitrogen either leaches away or feeds winter weeds. Apply at the wrong height of summer and you risk burning the lawn or triggering a disease outbreak in the humidity. Here is the calendar we follow for St. Augustine, Bermuda, and Zoysia lawns in LaPlace, Reserve, and the surrounding area.
+        </p>
+
+        <table class="calendar-table">
+          <thead>
+            <tr>
+              <th>Month</th>
+              <th>What to Apply</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="month-name">March</td>
+              <td class="fertilizer-rec">15-5-10 with pre-emergent</td>
+              <td>Apply after the last frost when grass is 50%+ green. The pre-emergent stops crabgrass and goosegrass before they germinate. Water in lightly if no rain is forecast within 48 hours.</td>
+            </tr>
+            <tr>
+              <td class="month-name">April</td>
+              <td class="fertilizer-rec">Spot-treat weeds only</td>
+              <td>Avoid additional nitrogen. The March application is still feeding. If weeds appear, spot-spray with a broadleaf herbicide &mdash; do not use a &ldquo;weed and feed&rdquo; product, which applies nitrogen at the wrong time and spreads herbicide where it is not needed.</td>
+            </tr>
+            <tr>
+              <td class="month-name">May</td>
+              <td class="fertilizer-rec">15-0-15 with slow-release N</td>
+              <td>Second feeding of the year. Zero phosphorus, consistent with Louisiana regulations. Use a slow-release formulation to carry the lawn through the early summer heat.</td>
+            </tr>
+            <tr>
+              <td class="month-name">June</td>
+              <td class="fertilizer-rec">Water and mow, do not feed</td>
+              <td>Let the May application do its work. Focus on <a href="blog-mowing-height-guide.html">proper mowing height</a> (3 to 4 inches for St. Augustine, 1.5 to 2.5 for Bermuda) and deep, infrequent watering. Extra nitrogen now invites brown patch and gray leaf spot.</td>
+            </tr>
+            <tr>
+              <td class="month-name">July</td>
+              <td class="fertilizer-rec">Iron supplement only</td>
+              <td><strong>No nitrogen in July.</strong> Do not apply any N during peak summer heat. Instead, use liquid iron (chelated iron) or iron sulfate to green up the lawn without stimulating leaf growth that the roots cannot support.</td>
+            </tr>
+            <tr>
+              <td class="month-name">August</td>
+              <td class="fertilizer-rec">Foliar iron or seaweed</td>
+              <td>Continue with iron or a <a href="blog-watering-guide.html">light seaweed foliar spray</a> if the lawn looks pale. Avoid granular nitrogen. Focus on hydrating the lawn through the dog days.</td>
+            </tr>
+            <tr>
+              <td class="month-name">September</td>
+              <td class="fertilizer-rec">Winterizer 5-10-20</td>
+              <td>The most important application for next year&rsquo;s lawn. High potassium and phosphorus (if soil-test-approved) help the grass store carbohydrates in roots and stolons. Apply 4 to 6 weeks before the first expected frost &mdash; usually mid-September in the River Parishes.</td>
+            </tr>
+            <tr>
+              <td class="month-name">October</td>
+              <td class="fertilizer-rec">None &mdash; let the grass harden off</td>
+              <td>Do not fertilize in October. The grass is naturally slowing down. Pushing growth now produces tender tissue that winter freezes will kill, leading to spring dead spots.</td>
+            </tr>
+            <tr>
+              <td class="month-name">Nov &ndash; Feb</td>
+              <td class="fertilizer-rec">Dormancy &mdash; no fertilizer</td>
+              <td>Warm-season grasses are fully dormant. Fertilizer applied now leaches into groundwater or feeds winter weeds. Wait until March green-up.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>Adjusting for Specific Grass Types</h3>
+        <p>
+          Different grasses have different appetites. <a href="blog-grass-types.html">Review our grass types guide</a> for a full comparison, but here are the key differences:
+        </p>
+        <ul>
+          <li><strong>St. Augustine:</strong> Moderate feeder. Use about 2 to 3 pounds of nitrogen per 1,000 sq ft per year. Be conservative with nitrogen in summer &mdash; St. Augustine is the most susceptible to brown patch and gray leaf spot during hot, wet weather.</li>
+          <li><strong>Bermuda:</strong> Heavy feeder. Can handle 3 to 5 pounds of nitrogen per 1,000 sq ft per year. Responds well to the March/May/September schedule above, but can take an extra light feeding in June if it is actively growing and being heavily used.</li>
+          <li><strong>Zoysia:</strong> Light to moderate feeder. Stay at the lower end &mdash; 2 to 3 pounds of nitrogen per 1,000 sq ft per year. Too much nitrogen on Zoysia produces soft, thatch-prone turf.</li>
+          <li><strong>Centipede:</strong> Very light feeder. One application in May at most. Centipede is native to low-fertility soils and turns yellow or dies out when over-fertilized.</li>
+        </ul>
+
+        <h2>Organic Fertilizer Options</h2>
+        <p>
+          Not everyone wants synthetic fertilizers. Organic options work well in Louisiana when applied correctly. They release nutrients more slowly, improve soil structure (which our clay soils desperately need), and support microbial activity. The trade-off is slower visible results and often a higher price per pound of nitrogen.
+        </p>
+
+        <h3>Compost Tea</h3>
+        <p>
+          Aerobically brewed compost tea introduces beneficial bacteria, fungi, and protozoa to the soil and leaf surface. Applied as a foliar spray or soil drench, it improves nutrient cycling and can suppress foliar diseases like gray leaf spot. Use a 5-gallon bucket with an aquarium pump, finished compost, and a mesh bag. Brew for 24 to 36 hours and apply within 4 hours for maximum microbial activity.
+        </p>
+
+        <h3>Milorganite</h3>
+        <p>
+          Milorganite is a heat-dried, granulated biosolid from Milwaukee&rsquo;s wastewater treatment process. It contains about 6-4-0 with slow-release nitrogen and significant iron. It is nearly impossible to burn the lawn with Milorganite, making it a great choice for homeowners nervous about application rates. In Louisiana&rsquo;s heat, it breaks down steadily and provides a gentle green-up over 8 to 10 weeks. Apply at 14 to 15 pounds per 1,000 sq ft.
+        </p>
+
+        <h3>Liquid Seaweed (Kelp Extract)</h3>
+        <p>
+          Liquid seaweed is not a complete fertilizer &mdash; its N-P-K is low (around 1-0-4) &mdash; but it is loaded with cytokinins, auxins, trace minerals, and amino acids that stimulate root growth and improve stress tolerance. It is especially valuable during July and August when the lawn is struggling with heat stress. Apply as a foliar spray every 3 to 4 weeks during the growing season.
+        </p>
+
+        <div class="tip-box">
+          <h4>Organic Fertilizer Schedule at a Glance</h4>
+          <p><strong>March:</strong> Milorganite (6-4-0) at 14 lbs per 1,000 sq ft</p>
+          <p><strong>May:</strong> Milorganite again + foliar compost tea</p>
+          <p><strong>July:</strong> Liquid seaweed weekly or biweekly &mdash; skip the Milorganite</p>
+          <p><strong>September:</strong> Milorganite + liquid seaweed combined</p>
+        </div>
+
+        <h2>Signs of Over-Fertilization and Under-Fertilization</h2>
+        <p>
+          Learning to read your lawn&rsquo;s signals can save you from expensive mistakes. Here is what to look for:
+        </p>
+
+        <div class="sign-grid">
+          <div class="sign-card over">
+            <h4>Over-Fertilization Signs</h4>
+            <ul>
+              <li>Leaf blades turning brown or yellow at the tips (fertilizer burn)</li>
+              <li>Excessive, rapid growth requiring mowing every 3 to 4 days</li>
+              <li>Soft, weak tissue that tears instead of cutting cleanly</li>
+              <li>Dark green color followed by sudden browning</li>
+              <li>White crust or salt deposits on the soil surface</li>
+              <li>Increased disease pressure (brown patch, dollar spot, gray leaf spot)</li>
+              <li>Crumbly or dried-out root zone despite adequate watering</li>
+            </ul>
+            <span class="photo-desc">Photo: A St. Augustine lawn showing marginal leaf burn &mdash; brown edges along the blade tips where excess nitrogen salts have desiccated the tissue. The affected area follows a linear spread pattern matching a spreader pass.</span>
+          </div>
+          <div class="sign-card under">
+            <h4>Under-Fertilization Signs</h4>
+            <ul>
+              <li>Uniformly pale green or yellow-green color across the lawn</li>
+              <li>Slow growth and thin turf with visible soil between blades</li>
+              <li>Weeds filling in the gaps &mdash; especially clover and nutsedge</li>
+              <li>Poor recovery from foot traffic or pet urine</li>
+              <li>Early fall dormancy and delayed spring green-up</li>
+              <li>Leaf blades narrower than normal for the grass type</li>
+              <li>Iron chlorosis (yellow leaves with green veins) on new growth</li>
+            </ul>
+            <span class="photo-desc">Photo: A nitrogen-starved Bermuda lawn exhibiting uniform chlorosis &mdash; pale yellow-green color across the entire lawn, thin canopy with bare soil visible, and clover invasion beginning at the edges. The lawn recovers slowly after mowing.</span>
+          </div>
+        </div>
+
+        <div class="tip-box">
+          <h4>The 24-Hour Test</h4>
+          <p>If you suspect over-fertilization, water the lawn deeply with 1 inch of water to flush excess salts below the root zone. Apply a light application of a humic acid product to help bind residual salts. Then wait 24 hours. If the grass is actively worsening (more tip browning, wilting), it is over-fertilization. If it is not changing, look for other issues like disease, compaction, or insect damage.</p>
+        </div>
+
+        <h2>Common Fertilizing Mistakes to Avoid</h2>
+        <p>
+          Over the years we have seen the same mistakes cost homeowners time, money, and a healthy lawn. Here are the biggest ones to avoid.
+        </p>
+
+        <h3>Fertilizing Dormant Grass</h3>
+        <p>
+          This is the most common mistake. Warm-season grass turns brown and stops growing in winter. Applying fertilizer to dormant grass does nothing for the lawn. The nitrogen either runs off into local waterways or feeds winter weeds like annual bluegrass and henbit. Wait until the lawn is at least 50 percent green in the spring before applying anything.
+        </p>
+
+        <div class="warning-box">
+          <h4>Dormant = Do Not Feed</h4>
+          <p>From November through February, put the fertilizer away. If you feel the urge to do something, apply a light top-dressing of compost or rake the lawn to break up thatch. That actually helps without harming the environment.</p>
+        </div>
+
+        <h3>Applying Before Heavy Rain</h3>
+        <p>
+          Louisiana gets 60-plus inches of rain per year. Checking the forecast before you spread fertilizer is essential. If heavy rain is expected within 24 hours, wait. Granular fertilizer that washes into storm drains, ditches, or the Mississippi River contributes to the Gulf of Mexico dead zone. It also wastes your money. If you have already applied and unexpected rain is coming, this is another reason to use slow-release formulations &mdash; they are less prone to runoff than quick-release products.
+        </p>
+
+        <h3>Using the Wrong Spreader Settings</h3>
+        <p>
+          A broadcast spreader (rotary) and a drop spreader apply fertilizer very differently. Using a rotary spreader on a narrow strip of lawn near a driveway throws product onto the pavement, where the next rain washes it into the storm drain. Using a drop spreader on a large open area takes twice as long and leaves stripes if you misalign your passes.
+        </p>
+        <p>
+          <strong>For most River Parishes lawns,</strong> we recommend a rotary (broadcast) spreader for open front and back yards, and a hand-held spreader for side strips and tight areas. Calibrate your spreader according to the bag settings, then do a test pass on the driveway to confirm the actual spread width before you hit the grass.
+        </p>
+
+        <h3>Other Common Errors</h3>
+        <ul>
+          <li><strong>Using weed-and-feed products at the wrong time.</strong> These combine fertilizer with herbicide. If the weeds are not actively growing, you waste the herbicide. If the lawn does not need nitrogen, you waste the fertilizer. We prefer addressing weeds and fertility as separate tasks.</li>
+          <li><strong>Applying the same rate everywhere.</strong> Shady areas need less fertilizer than sunny areas. Slopes need less than flat ground. Adjust your rate based on the area &mdash; not the whole lawn at the same setting.</li>
+          <li><strong>Skipping the soil test.</strong> A $10 soil test from the LSU AgCenter can save you $50 to $100 per year in wasted fertilizer and lost grass from guessing wrong. It is the single most cost-effective step in lawn care.</li>
+          <li><strong>Not watering after granular application.</strong> Most granular fertilizers need about a quarter-inch of water within 48 hours to carry nutrients into the root zone. Without water, the granules sit on the surface and the nitrogen can volatilize (turn to gas and float away), especially in our summer heat.</li>
+        </ul>
+
+        <div class="cta-section">
+          <h3>Get a Professional Fertilizing Plan</h3>
+          <p>
+            Not sure what your lawn needs? We offer soil test interpretation, custom fertilizing schedules, and full-service applications throughout the River Parishes. Our team knows which products work on Louisiana clay and which are a waste of money.
+          </p>
+          <a href="home.html#waitlist" class="btn">Request a Free Quote</a>
+        </div>
+
+        <h2>Related Posts</h2>
+        <ul>
+          <li>
+            <a href="blog-grass-types.html">Best Grass Types for LaPlace, Louisiana</a>
+            &mdash; Match your fertilizer strategy to your grass variety.
+          </li>
+          <li>
+            <a href="blog-mowing-height-guide.html">The Complete Guide to Mowing Height for Louisiana Lawns</a>
+            &mdash; Proper mowing height works hand in hand with fertilization for healthier turf.
+          </li>
+          <li>
+            <a href="blog-watering-guide.html">Lawn Watering Guide for Louisiana&rsquo;s Climate</a>
+            &mdash; Fertilizer and watering must work together. Learn when and how much to water.
+          </li>
+        </ul>
+
+        <a href="home.html#blog" class="back-link">&larr; Back to All Articles</a>
+      </article>
+    </div>
+
+    <footer class="blog-footer">
+      <p><strong>&copy; 2025 Xcellent1 Lawn Care</strong></p>
+      <p style="font-size: 0.9rem; opacity: 0.8">
+        Serving the River Parishes, Louisiana
+      </p>
+    </footer>
+  </body>
+</html>

--- a/web/static/blog-grass-types.html
+++ b/web/static/blog-grass-types.html
@@ -602,6 +602,23 @@
           </p>
           <a href="home.html#waitlist" class="btn">Get a Free Consultation →</a>
         </div>
+    <div class="related-posts">
+      <h3 style="color:#1f2937; margin-bottom: 1rem; font-size: 1.25rem;">📚 Related Guides</h3>
+      <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem;">
+        <a href="blog-watering-guide.html" style="display: block; padding: 1rem; background: #f9fafb; border-radius: 10px; text-decoration: none; color: #374151; border: 1px solid #e5e7eb;">
+          <strong style="color: #10b981;">💧</strong>
+          <span style="font-size: 0.9rem;">Louisiana Lawn Watering Guide</span>
+        </a>
+        <a href="blog-fertilizing-guide.html" style="display: block; padding: 1rem; background: #f9fafb; border-radius: 10px; text-decoration: none; color: #374151; border: 1px solid #e5e7eb;">
+          <strong style="color: #10b981;">🧪</strong>
+          <span style="font-size: 0.9rem;">How to Fertilize a Louisiana Lawn</span>
+        </a>
+        <a href="blog-sod-installation-guide.html" style="display: block; padding: 1rem; background: #f9fafb; border-radius: 10px; text-decoration: none; color: #374151; border: 1px solid #e5e7eb;">
+          <strong style="color: #10b981;">🟢</strong>
+          <span style="font-size: 0.9rem;">Sod Installation Guide</span>
+        </a>
+      </div>
+    </div>
 
         <a href="home.html#blog" class="back-link">← Back to All Articles</a>
       </article>

--- a/web/static/blog-mowing-height-guide.html
+++ b/web/static/blog-mowing-height-guide.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mowing Height & Edging for South Louisiana Lawns | Xcellent1 Lawn Care Blog</title>
+    <meta name="description" content="Cut height, mowing frequency, edging, and trimming tips that keep Louisiana lawns healthy." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://xcellent1lawncare.com/blog-mowing-height-guide" />
+    <meta property="og:title" content="Mowing Height & Edging for South Louisiana Lawns" />
+    <meta property="og:description" content="Cut height, mowing frequency, edging, and trimming tips that keep Louisiana lawns healthy." />
+    <meta property="og:image" content="https://xcellent1lawncare.com/images/CoverPhoto.webp" />
+    <meta property="article:published_time" content="2025-11-29" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Mowing Height & Edging for South Louisiana Lawns" />
+    <meta name="twitter:description" content="Cut height, mowing frequency, edging, and trimming tips that keep Louisiana lawns healthy." />
+    <link rel="canonical" href="https://xcellent1lawncare.com/blog-mowing-height-guide" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon.ico" />
+    <link rel="stylesheet" href="styles.clean.css" />
+    <meta name="theme-color" content="#3b832a" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "Mowing Height & Edging for South Louisiana Lawns",
+        "description": "Cut height, mowing frequency, edging, and trimming tips that keep Louisiana lawns healthy.",
+        "author": { "@type": "Organization", "name": "Xcellent1 Lawn Care" },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Xcellent1 Lawn Care"
+        },
+        "datePublished": "2025-11-29",
+        "mainEntityOfPage": {
+          "@type": "WebPage",
+          "@id": "https://xcellent1lawncare.com/blog-mowing-height-guide"
+        }
+      }
+    </script>
+    <style>
+      .blog-hero {
+        background: linear-gradient(135deg, rgba(59, 131, 42, 0.92), rgba(19, 63, 28, 0.96)), url("/images/CoverPhoto.webp") center/cover;
+        padding: 5rem 1rem;
+        text-align: center;
+        color: #fff;
+      }
+      .blog-hero h1 {
+        font-size: clamp(2rem, 4vw, 3.2rem);
+        margin-bottom: 0.75rem;
+        font-weight: 800;
+        text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+      }
+      .blog-hero .meta {
+        font-size: 0.95rem;
+        opacity: 0.95;
+        display: flex;
+        justify-content: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+      .reading-time {
+        background: rgba(255, 255, 255, 0.2);
+        padding: 0.25rem 0.75rem;
+        border-radius: 20px;
+        font-size: 0.85rem;
+      }
+      .blog-container {
+        max-width: 860px;
+        margin: -3rem auto 0;
+        padding: 0 1rem 2rem;
+        position: relative;
+        z-index: 10;
+      }
+      .blog-content {
+        background: #fff;
+        border-radius: 16px;
+        padding: 2.25rem;
+        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
+      }
+      .blog-content > p:first-of-type {
+        font-size: 1.15rem;
+        color: #4b5563;
+        line-height: 1.8;
+      }
+      .blog-content h2 {
+        color: #166534;
+        margin: 2.5rem 0 1rem;
+        font-size: 1.5rem;
+        position: relative;
+        padding-bottom: 0.5rem;
+      }
+      .blog-content h2::after {
+        content: "";
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 60px;
+        height: 3px;
+        background: linear-gradient(90deg, #22c55e, #3b832a);
+        border-radius: 2px;
+      }
+      .blog-content p, .blog-content li {
+        line-height: 1.8;
+        color: #374151;
+        font-size: 1.02rem;
+      }
+      .blog-content ul {
+        margin: 0.75rem 0 1.5rem;
+        padding-left: 1.25rem;
+      }
+      .related {
+        border-top: 1px solid #e5e7eb;
+        margin-top: 2rem;
+        padding-top: 1.5rem;
+      }
+      .related a {
+        color: #166534;
+        text-decoration: none;
+        font-weight: 700;
+      }
+      .cta-box {
+        margin-top: 2rem;
+        padding: 1.2rem 1.4rem;
+        border-radius: 14px;
+        background: #f0fdf4;
+        border: 1px solid #bbf7d0;
+      }
+      .cta-box a { color: #14532d; font-weight: 800; }
+      .backlink {
+        display: inline-block;
+        margin-top: 1.5rem;
+        color: #166534;
+        font-weight: 700;
+      }
+      @media (max-width: 640px) {
+        .blog-content { padding: 1.35rem; }
+        .blog-hero { padding: 4rem 1rem 2.5rem; }
+      }
+    </style>
+  </head>
+  <body>
+    <header class="blog-hero">
+      <div class="blog-container">
+        <h1>Mowing Height & Edging for South Louisiana Lawns</h1>
+        <div class="meta">
+          <span>📅 2025-11-29</span>
+          <span class="reading-time">📖 6 min read</span>
+          <span>Maintenance · South Louisiana</span>
+        </div>
+      </div>
+    </header>
+
+    <main class="blog-container">
+      <article class="blog-content">
+        <p>Mowing is the most important lawn care task you'll do all year. In South Louisiana's humid climate, cutting your grass at the right height and frequency determines whether your lawn fights off weeds and disease — or struggles through summer. Let's get it right.</p>
+
+        <h2>Mowing Heights by Grass Type</h2>
+        <p>Each warm-season grass needs a different cut height to stay healthy. Scalping a St. Augustine lawn (cutting it too short) can kill it. Cutting Bermuda too tall lets weeds take over.</p>
+
+        <div style="overflow-x:auto;">
+        <table style="width:100%; border-collapse: collapse; margin: 1rem 0;">
+          <thead><tr style="background: #f0fdf4;"><th style="padding:0.75rem;text-align:left;border:1px solid #d1fae5;">Grass Type</th><th style="padding:0.75rem;text-align:left;border:1px solid #d1fae5;">Ideal Height</th><th style="padding:0.75rem;text-align:left;border:1px solid #d1fae5;">Summer Height</th><th style="padding:0.75rem;text-align:left;border:1px solid #d1fae5;">Last Cut (Fall)</th><th style="padding:0.75rem;text-align:left;border:1px solid #d1fae5;">Notes</th></tr></thead>
+          <tbody>
+            <tr><td style="padding:0.75rem;border:1px solid #e5e7eb;">St. Augustine</td><td style="padding:0.75rem;border:1px solid #e5e7eb;">3.5–4.5 in</td><td style="padding:0.75rem;border:1px solid #e5e7eb;">4–5 in</td><td style="padding:0.75rem;border:1px solid #e5e7eb;">4 in</td><td style="padding:0.75rem;border:1px solid #e5e7eb;">Most shade-tolerant; NEVER scalp below 3 in</td></tr>
+            <tr style="background:#f9fafb;"><td style="padding:0.75rem;border:1px solid #e5e7eb;">Bermuda</td><td style="padding:0.75rem;border:1px solid #e5e7eb;">1–2 in</td><td style="padding:0.75rem;border:1px solid #e5e7eb;">2–2.5 in</td><td style="padding:0.75rem;border:1px solid #e5e7eb;">1.5 in</td><td style="padding:0.75rem;border:1px solid #e5e7eb;">Needs full sun; can be scalped in spring to remove thatch</td></tr>
+            <tr><td style="padding:0.75rem;border:1px solid #e5e7eb;">Zoysia</td><td style="padding:0.75rem;border:1px solid #e5e7eb;">1–2.5 in</td><td style="padding:0.75rem;border:1px solid #e5e7eb;">2–3 in</td><td style="padding:0.75rem;border:1px solid #e5e7eb;">2 in</td><td style="padding:0.75rem;border:1px solid #e5e7eb;">Slow-growing; needs less frequent mowing</td></tr>
+            <tr style="background:#f9fafb;"><td style="padding:0.75rem;border:1px solid #e5e7eb;">Centipede</td><td style="padding:0.75rem;border:1px solid #e5e7eb;">1.5–2.5 in</td><td style="padding:0.75rem;border:1px solid #e5e7eb;">2–3 in</td><td style="padding:0.75rem;border:1px solid #e5e7eb;">2 in</td><td style="padding:0.75rem;border:1px solid #e5e7eb;">Low-maintenance but sensitive to scalping and high nitrogen</td></tr>
+          </tbody>
+        </table>
+        </div>
+        <p style="font-size:0.85rem;color:#6b7280;">Heights are for warm-season lawns in South Louisiana. Raise by 0.5–1 in during summer heat stress.</p>
+
+        <h2>The 1/3 Rule: Never Cut More Than One-Third</h2>
+        <p>The cardinal rule of mowing: <strong>never remove more than 1/3 of the grass blade at once.</strong> If your St. Augustine has grown to 6 inches, don't scalp it down to 3 inches in one pass. Mow to 4 inches, wait a few days, then drop to 3.5 inches.</p>
+        <p>Removing more than 1/3 shocks the plant. The grass redirects energy from root growth to leaf recovery — leaving roots shallow and the lawn vulnerable to drought, weeds, and disease. In Louisiana's hot summers, a scalped lawn can take weeks to recover.</p>
+        <p><strong>What to do if you missed a week:</strong> Raise your mower deck to the highest setting. Mow. Wait 3-4 days. Mow again at your normal height. Never try to fix neglect in one pass.</p>
+
+        <h2>Mowing Frequency: How Often to Mow in Louisiana</h2>
+        <p>Frequency depends on the season, grass type, and rainfall. Use this guide for the River Parishes:</p>
+        <ul>
+          <li><strong>Peak growing season (April–October):</strong> Weekly for St. Augustine; every 5-7 days for Bermuda and Zoysia. Grass grows fast in Louisiana heat and humidity.</li>
+          <li><strong>Slow season (November–March):</strong> Every 2-3 weeks for all types. Warm-season grasses go dormant or slow down significantly.</li>
+          <li><strong>After rain:</strong> A heavy Louisiana thunderstorm can add 1-2 inches of growth in days. Check the lawn 2-3 days after significant rain.</li>
+          <li><strong>When to stop for winter:</strong> Gradually raise the mowing height starting in October. The final fall cut should be about 0.5–1 inch higher than summer height.</li>
+        </ul>
+
+        <h2>Blade Sharpness: The Overlooked Essential</h2>
+        <p>A dull mower blade tears grass instead of cutting it cleanly. The shredded tips turn brown within 24 hours, giving the lawn a ragged look. More importantly, torn grass blades lose more moisture and are more susceptible to fungal diseases — a major concern in Louisiana's humid climate.</p>
+        <ul>
+          <li><strong>Sharpen blades</strong> at least twice per season. For a 1/2-acre lawn, that means 3-4 times per year.</li>
+          <li><strong>Signs of a dull blade:</strong> Ragged brown tips on grass blades, grass that looks "shredded" after mowing, uneven cut, the mower vibrating more than usual.</li>
+          <li><strong>Pro tip:</strong> Keep a spare sharpened blade on hand. Swap and sharpen on rotation so you're never mowing with a dull blade.</li>
+        </ul>
+
+        <h2>Mowing Patterns: Change Direction Every Time</h2>
+        <p>Mowing the same direction every week creates ruts and compacts soil in wheel tracks. It also trains grass to lean in one direction, reducing the uniform look.</p>
+        <ul>
+          <li>Week 1: Mow north-south.</li>
+          <li>Week 2: Mow east-west.</li>
+          <li>Week 3: Mow diagonally (NW-SE).</li>
+          <li>Week 4: Mow the opposite diagonal (NE-SW).</li>
+          <li>Then repeat. This also helps the lawn stand upright for a cleaner cut.</li>
+        </ul>
+
+        <h2>Grasscycling: Leave the Clippings</h2>
+        <p>Contrary to old advice, grass clippings should stay on the lawn — not go in bags. Clippings are 85% water and break down quickly, returning nitrogen to the soil. This practice provides up to 25% of your lawn's annual nitrogen needs.</p>
+        <ul>
+          <li><strong>When to bag:</strong> If clippings are excessive (missed a week and they clump), or if treating a fungal disease and removing infected material.</li>
+          <li><strong>When NOT to bag:</strong> Regular weekly mowing. Leave clippings to decompose. It saves time, reduces landfill waste, and feeds your lawn.</li>
+          <li><strong>Mulching mowers</strong> cut clippings into finer pieces. If using a side-discharge mower, mow over heavy clippings a second time.</li>
+        </ul>
+
+        <h2>Edging: The Finishing Touch</h2>
+        <p>A sharp edge between lawn and flower beds or walkways makes the entire property look professionally maintained. It also prevents grass from creeping into beds.</p>
+        <ul>
+          <li><strong>Edge every 2-3 mowings</strong> during growing season.</li>
+          <li><strong>Use a half-moon edger or power edger</strong> for a clean vertical cut along sidewalks and driveways.</li>
+          <li><strong>String trimmers are for detail work</strong> — around trees, fence posts, and tight corners.</li>
+          <li><strong>Avoid "mower rash"</strong> — nicking flower bed edges. Edging creates a clean buffer zone.</li>
+        </ul>
+
+        <h2>Common Mowing Mistakes in South Louisiana</h2>
+        <ul>
+          <li><strong>Scalping St. Augustine:</strong> The #1 mowing killer in the River Parishes. Scalping exposes runners to sun and heat. St. Augustine is a bunch-type grass — it doesn't fill back in quickly.</li>
+          <li><strong>Mowing wet grass:</strong> After a Louisiana thunderstorm, wait a day to mow. Wet soil ruts and spreads fungal disease.</li>
+          <li><strong>Same pattern every week:</strong> Creates wheel ruts and compacted soil. Vary direction.</li>
+          <li><strong>Removing too much:</strong> Follow the 1/3 rule. Raise height and mow again in 3-4 days if needed.</li>
+          <li><strong>Mowing too short before summer:</strong> Weakens roots before the brutal June-August heat. Keep St. Augustine at 3.5-4 inches.</li>
+          <li><strong>Bagging unnecessarily:</strong> You're removing free fertilizer. Grasscycle unless there's a disease concern.</li>
+        </ul>
+
+        <h2>When to Call a Professional</h2>
+        <p>If you're spending 2-3 hours every week on mowing and edging — or not getting the results you want — professional service might be right. Xcellent1 covers the entire River Parishes with consistent crews that follow best practices for every grass type.</p>
+
+        <div class="cta-section" style="background: linear-gradient(135deg, #3b832a 0%, #10b981 100%); border-radius: 16px; padding: 2rem; text-align: center; margin: 2rem 0;">
+          <h3 style="color: #fff; margin: 0 0 0.5rem;">Let Us Handle the Mowing</h3>
+          <p style="color: rgba(255,255,255,0.9); margin: 0 0 1.25rem;">Professional lawn service starting at competitive rates. Free quotes.</p>
+          <a href="home.html#waitlist" class="btn" style="background: #fff; color: #10b981; padding: 0.75rem 2rem; border-radius: 10px; font-weight: 600; text-decoration: none; display: inline-block;">Get a Free Quote →</a>
+        </div>
+
+        <div class="related-posts" style="margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid #e5e7eb;">
+          <h3 style="color:#1f2937; margin-bottom: 1rem; font-size: 1.25rem;">📚 Related Guides</h3>
+          <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem;">
+            <a href="blog-grass-types.html" style="display: block; padding: 1rem; background: #f9fafb; border-radius: 10px; text-decoration: none; color: #374151; border: 1px solid #e5e7eb;">
+              <strong style="color: #10b981;">🌿</strong>
+              <span style="font-size: 0.9rem;">Best Grass Types for LaPlace</span>
+            </a>
+            <a href="blog-fertilizing-guide.html" style="display: block; padding: 1rem; background: #f9fafb; border-radius: 10px; text-decoration: none; color: #374151; border: 1px solid #e5e7eb;">
+              <strong style="color: #10b981;">🧪</strong>
+              <span style="font-size: 0.9rem;">How to Fertilize a Louisiana Lawn</span>
+            </a>
+            <a href="blog-weed-control-guide.html" style="display: block; padding: 1rem; background: #f9fafb; border-radius: 10px; text-decoration: none; color: #374151; border: 1px solid #e5e7eb;">
+              <strong style="color: #10b981;">🌱</strong>
+              <span style="font-size: 0.9rem;">Weed Control Guide</span>
+            </a>
+          </div>
+        </div>
+
+        <a href="blog.html" class="back-link" style="display: inline-block; margin-top: 1.5rem; color: #047857; font-weight: 600; text-decoration: none;">← Back to All Articles</a>
+      </article>
+    </main>
+  </body>
+</html>

--- a/web/static/blog-pest-disease-guide.html
+++ b/web/static/blog-pest-disease-guide.html
@@ -1,0 +1,458 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pest & Disease Guide for Louisiana Lawns | Xcellent1 Lawn Care Blog</title>
+    <meta name="description" content="Complete guide to identifying and treating lawn pests and diseases in South Louisiana. Chinch bugs, armyworms, brown patch, and more." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://xcellent1lawncare.com/blog-pest-disease-guide" />
+    <meta property="og:title" content="Pest & Disease Guide for Louisiana Lawns" />
+    <meta property="og:description" content="Complete guide to identifying and treating lawn pests and diseases in South Louisiana. Chinch bugs, armyworms, brown patch, and more." />
+    <meta property="og:image" content="https://xcellent1lawncare.com/images/CoverPhoto.webp" />
+    <meta property="article:published_time" content="2025-12-13" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Pest & Disease Guide for Louisiana Lawns" />
+    <meta name="twitter:description" content="Complete guide to identifying and treating lawn pests and diseases in South Louisiana." />
+    <link rel="canonical" href="https://xcellent1lawncare.com/blog-pest-disease-guide" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon.ico" />
+    <link rel="stylesheet" href="styles.clean.css" />
+    <meta name="theme-color" content="#3b832a" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "Pest & Disease Guide for Louisiana Lawns",
+        "description": "Complete guide to identifying and treating lawn pests and diseases in South Louisiana.",
+        "author": { "@type": "Organization", "name": "Xcellent1 Lawn Care" },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Xcellent1 Lawn Care"
+        },
+        "datePublished": "2025-12-13",
+        "mainEntityOfPage": {
+          "@type": "WebPage",
+          "@id": "https://xcellent1lawncare.com/blog-pest-disease-guide"
+        }
+      }
+    </script>
+    <style>
+      .blog-hero {
+        background: linear-gradient(135deg, rgba(59, 131, 42, 0.92), rgba(19, 63, 28, 0.96)), url("/images/CoverPhoto.webp") center/cover;
+        padding: 5rem 1rem;
+        text-align: center;
+        color: #fff;
+      }
+      .blog-hero h1 {
+        font-size: clamp(2rem, 4vw, 3.2rem);
+        margin-bottom: 0.75rem;
+        font-weight: 800;
+        text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+      }
+      .blog-hero .meta {
+        font-size: 0.95rem;
+        opacity: 0.95;
+        display: flex;
+        justify-content: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+      .reading-time {
+        background: rgba(255, 255, 255, 0.2);
+        padding: 0.25rem 0.75rem;
+        border-radius: 20px;
+        font-size: 0.85rem;
+      }
+      .blog-container {
+        max-width: 860px;
+        margin: -3rem auto 0;
+        padding: 0 1rem 2rem;
+        position: relative;
+        z-index: 10;
+      }
+      .blog-content {
+        background: #fff;
+        border-radius: 16px;
+        padding: 2.25rem;
+        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
+      }
+      .blog-content > p:first-of-type {
+        font-size: 1.15rem;
+        color: #4b5563;
+        line-height: 1.8;
+      }
+      .blog-content h2 {
+        color: #166534;
+        margin: 2.5rem 0 1rem;
+        font-size: 1.5rem;
+        position: relative;
+        padding-bottom: 0.5rem;
+      }
+      .blog-content h2::after {
+        content: "";
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 60px;
+        height: 3px;
+        background: linear-gradient(90deg, #22c55e, #3b832a);
+        border-radius: 2px;
+      }
+      .blog-content h3 {
+        color: #15803d;
+        margin: 1.75rem 0 0.75rem;
+        font-size: 1.2rem;
+      }
+      .blog-content p, .blog-content li {
+        line-height: 1.8;
+        color: #374151;
+        font-size: 1.02rem;
+      }
+      .blog-content ul {
+        margin: 0.75rem 0 1.5rem;
+        padding-left: 1.25rem;
+      }
+      .blog-content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1.25rem 0 1.75rem;
+        font-size: 0.95rem;
+        border-radius: 10px;
+        overflow: hidden;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+      }
+      .blog-content thead {
+        background: linear-gradient(135deg, #166534, #22c55e);
+        color: #fff;
+      }
+      .blog-content th {
+        padding: 0.75rem 1rem;
+        text-align: left;
+        font-weight: 700;
+        font-size: 0.9rem;
+        letter-spacing: 0.02em;
+      }
+      .blog-content td {
+        padding: 0.7rem 1rem;
+        border-bottom: 1px solid #e5e7eb;
+        color: #374151;
+        vertical-align: top;
+      }
+      .blog-content tbody tr:last-child td {
+        border-bottom: none;
+      }
+      .blog-content tbody tr:nth-child(even) {
+        background: #f9fafb;
+      }
+      .blog-content tbody tr:hover {
+        background: #f0fdf4;
+      }
+      .blog-content .warning-box {
+        background: #fef3c7;
+        border-left: 4px solid #f59e0b;
+        border-radius: 8px;
+        padding: 1rem 1.25rem;
+        margin: 1.25rem 0;
+      }
+      .blog-content .warning-box p {
+        margin: 0;
+        color: #92400e;
+      }
+      .blog-content .tip-box {
+        background: #f0fdf4;
+        border-left: 4px solid #22c55e;
+        border-radius: 8px;
+        padding: 1rem 1.25rem;
+        margin: 1.25rem 0;
+      }
+      .blog-content .tip-box p {
+        margin: 0;
+        color: #166534;
+      }
+      .blog-content .info-box {
+        background: #eff6ff;
+        border-left: 4px solid #3b82f6;
+        border-radius: 8px;
+        padding: 1rem 1.25rem;
+        margin: 1.25rem 0;
+      }
+      .blog-content .info-box p {
+        margin: 0;
+        color: #1e40af;
+      }
+      .related {
+        border-top: 1px solid #e5e7eb;
+        margin-top: 2rem;
+        padding-top: 1.5rem;
+      }
+      .related a {
+        color: #166534;
+        text-decoration: none;
+        font-weight: 700;
+      }
+      .cta-box {
+        margin-top: 2rem;
+        padding: 1.5rem 1.75rem;
+        border-radius: 14px;
+        background: linear-gradient(135deg, #f0fdf4, #dcfce7);
+        border: 1px solid #bbf7d0;
+        text-align: center;
+      }
+      .cta-box h3 {
+        margin: 0 0 0.5rem;
+        color: #166534;
+        font-size: 1.3rem;
+      }
+      .cta-box p {
+        margin: 0 0 0.75rem;
+        color: #374151;
+      }
+      .cta-box .cta-btn {
+        display: inline-block;
+        background: #16a34a;
+        color: #fff;
+        padding: 0.75rem 2rem;
+        border-radius: 10px;
+        font-weight: 700;
+        text-decoration: none;
+        font-size: 1.05rem;
+        transition: background 0.2s;
+      }
+      .cta-box .cta-btn:hover {
+        background: #15803d;
+      }
+      .cta-box a { color: #14532d; font-weight: 800; }
+      .backlink {
+        display: inline-block;
+        margin-top: 1.5rem;
+        color: #166534;
+        font-weight: 700;
+      }
+      @media (max-width: 640px) {
+        .blog-content { padding: 1.35rem; }
+        .blog-hero { padding: 4rem 1rem 2.5rem; }
+        .blog-content table { font-size: 0.85rem; }
+        .blog-content th, .blog-content td { padding: 0.5rem 0.6rem; }
+      }
+    </style>
+  </head>
+  <body>
+    <header class="blog-hero">
+      <div class="blog-container">
+        <h1>Pest & Disease Guide for Louisiana Lawns</h1>
+        <div class="meta">
+          <span>2025-12-13</span>
+          <span class="reading-time">12 min read</span>
+          <span>Pests & disease · Louisiana</span>
+        </div>
+      </div>
+    </header>
+
+    <main class="blog-container">
+      <article class="blog-content">
+        <p>South Louisiana humidity creates a perfect environment for lawn stress, insects, and fungus. A good lawn plan includes regular inspection, not just mowing and watering. Knowing what to look for and when to act can mean the difference between a minor problem and a full lawn renovation. This guide covers the most common pests and diseases in the River Parishes, how to identify them, and the most effective treatment strategies available.</p>
+
+        <h2>Insect Pest Identification Guide</h2>
+        <p>Many lawn problems in Louisiana look the same at first glance: yellowing grass, thinning patches, or sudden browning. The key to effective treatment is proper identification before you reach for any product. Misidentifying a pest can waste money and delay real solutions. Below are the four most damaging insects we see in St. Augustine and other warm-season lawns across the River Parishes.</p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Pest</th>
+              <th>Target Grass</th>
+              <th>Damage Pattern</th>
+              <th>Peak Season</th>
+              <th>Key Signs</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Chinch Bugs</strong></td>
+              <td>St. Augustine</td>
+              <td>Yellow to brown patches, starting at edges and spreading inward</td>
+              <td>June through August</td>
+              <td>Stolons snap easily; tiny black bugs with white wings at soil-thatch line</td>
+            </tr>
+            <tr>
+              <td><strong>Armyworms</strong></td>
+              <td>All grasses</td>
+              <td>Rapid defoliation — lawn looks scalped overnight</td>
+              <td>August through September</td>
+              <td>Green/brown striped caterpillars; birds flocking to lawn</td>
+            </tr>
+            <tr>
+              <td><strong>White Grubs</strong></td>
+              <td>All grasses, esp. St. Augustine</td>
+              <td>Irregular brown patches; turf pulls up like carpet</td>
+              <td>October through November</td>
+              <td>Skunks, armadillos, raccoons digging at night; C-shaped white larvae in soil</td>
+            </tr>
+            <tr>
+              <td><strong>Sod Webworms</strong></td>
+              <td>St. Augustine, Bermuda</td>
+              <td>Thin brown spots, ragged leaf edges</td>
+              <td>June through September</td>
+              <td>Small tan moths flying low at dusk; silk tunnels in thatch</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>Chinch Bugs — The #1 St. Augustine Threat</h3>
+        <p>Chinch bugs are by far the most destructive insect pest for St. Augustine grass in the River Parishes. These tiny insects (about 1/5 inch long as adults) feed by piercing grass stems and sucking sap while injecting a toxin that blocks the plant's vascular system. The first sign is usually yellow patches that appear drought-stressed, but the grass doesn't recover after watering. To confirm chinch bugs, part the grass at the edge of a damaged area and look at the soil-thatch interface. If you see small black bugs with white wing patches scurrying around, you have chinch bugs. A simple test: cut both ends off a tin can, push it into the soil at the damage edge, fill with water, and wait 5 minutes — chinch bugs will float to the surface.</p>
+
+        <div class="warning-box">
+          <p><strong>Louisiana warning:</strong> Chinch bugs are the #1 killer of St. Augustine grass in the River Parishes. Many homeowners mistake their damage for drought stress and water more, which only stresses the lawn further. If you have St. Augustine and see yellow-brown patches from June to August, inspect for chinch bugs before doing anything else.</p>
+        </div>
+
+        <h3>Armyworms — Overnight Destruction</h3>
+        <p>Armyworms get their name from their feeding behavior: they move across lawns in coordinated groups, consuming everything in their path. An armyworm infestation can turn a healthy green lawn into a brown, chewed mess in a single night. They are most active in late summer (August-September) when populations peak. Look for green or brown striped caterpillars about 1 to 1.5 inches long. A heavy bird presence on your lawn, especially early morning, is often the first clue homeowners notice. Armyworms feed on all grass types but are especially damaging to young or recently fertilized lawns where growth is tender.</p>
+
+        <h3>White Grubs — Hidden Root Damage</h3>
+        <p>White grubs are the larvae of June beetles and other scarabs. They live below the soil surface and feed on grass roots, gradually weakening the turf until it can be rolled back like a carpet. Because the damage is underground, you may not notice grubs until skunks, armadillos, or raccoons start tearing up your lawn looking for them. If you see animal digging activity in October or November, check for grubs by cutting a 1-square-foot section of turf about 3 inches deep and peeling it back. Healthy lawns can tolerate 5-8 grubs per square foot, but numbers above 10-15 require treatment.</p>
+
+        <h3>Sod Webworms</h3>
+        <p>Sod webworms are less destructive than chinch bugs or armyworms but can still cause noticeable thinning. The adult moths are small and tan, and you will see them fluttering low over the lawn at dusk. The real damage comes from the larvae, which feed on grass blades at night and construct silk-lined tunnels in the thatch layer. Damage appears as irregular brown spots with notched leaf blades. Infestations are most common in hot, dry weather.</p>
+
+        <h2>Disease Identification Guide</h2>
+        <p>Fungal diseases flourish in Louisiana's humid climate, especially during the transition periods between seasons when temperature and moisture levels fluctuate. Proper identification is critical because fungicides are specific to disease types, and misapplication is both wasteful and ineffective.</p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Disease</th>
+              <th>Affected Grass</th>
+              <th>Appearance</th>
+              <th>Conditions</th>
+              <th>Season</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Brown Patch</strong></td>
+              <td>All grasses, esp. St. Augustine</td>
+              <td>Large circular patches, tan centers with dark borders</td>
+              <td>Night temps above 80°F, high humidity, excess nitrogen</td>
+              <td>Late spring through fall</td>
+            </tr>
+            <tr>
+              <td><strong>Large Patch</strong></td>
+              <td>St. Augustine, Zoysia</td>
+              <td>Large irregular yellow-to-brown lesions on leaf sheaths</td>
+              <td>Cool, wet weather; low mowing heights</td>
+              <td>Late fall through spring</td>
+            </tr>
+            <tr>
+              <td><strong>Dollar Spot</strong></td>
+              <td>All grasses</td>
+              <td>Small silver-dollar-sized sunken patches that merge into larger areas</td>
+              <td>Low nitrogen, heavy dew, dry soil</td>
+              <td>Late spring through fall</td>
+            </tr>
+            <tr>
+              <td><strong>Gray Leaf Spot</strong></td>
+              <td>St. Augustine</td>
+              <td>Small brown spots with gray centers on leaf blades</td>
+              <td>Warm, wet weather; overwatering</td>
+              <td>Summer, especially after storms</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>Brown Patch</h3>
+        <p>Brown patch is the most common fungal disease in Louisiana lawns. It appears as large, roughly circular patches of brown grass that can reach several feet in diameter. The patches often have a darker border — sometimes called a "smoke ring" — around the edge. Brown patch is caused by the fungus <em>Rhizoctonia solani</em> and is most active when nighttime temperatures stay above 80°F and humidity is high. Overwatering and excessive nitrogen fertilizer make it worse. In the River Parishes, brown patch often flares up after summer thunderstorms when hot days are followed by warm, humid nights.</p>
+
+        <h3>Large Patch</h3>
+        <p>Large patch is often confused with brown patch, but it occurs during cooler weather — late fall through early spring. It primarily affects St. Augustine and Zoysia grass. Symptoms include large, irregular yellow-to-brown lesions on leaf sheaths near the soil line. The leaves pull away easily from the stolon. Large patch is especially problematic when lawns are mowed too short going into winter or when fall fertilization is too heavy. Preventative fungicide applications in early fall can be very effective.</p>
+
+        <h3>Dollar Spot</h3>
+        <p>Dollar spot gets its name from the small, silver-dollar-sized patches of sunken, straw-colored grass it produces. These spots can merge into larger irregular areas as the disease progresses. Dollar spot is most common in lawns with low nitrogen levels and is aggravated by heavy dew and dry soil conditions. Unlike brown patch, dollar spot rarely kills the entire plant — the crown usually survives, and the grass can recover with proper fertilization and watering. Maintaining adequate nitrogen levels through proper <a href="blog-fertilizing-guide.html">seasonal fertilizing</a> is one of the best preventatives.</p>
+
+        <h3>Gray Leaf Spot</h3>
+        <p>Gray leaf spot is specific to St. Augustine grass and thrives in wet weather. It appears as small brown or purplish spots on leaf blades that develop gray centers as they mature. In severe cases, entire leaf blades die, giving the lawn a scorched appearance. Gray leaf spot is most common after prolonged rain or when lawns are watered in the evening. Improving <a href="blog-watering-guide.html">watering practices</a> — particularly switching to early morning irrigation — is the first and most important step in managing this disease.</p>
+
+        <div class="info-box">
+          <p><strong>Louisiana disease pressure:</strong> After summer thunderstorms, the combination of high heat and standing humidity creates ideal conditions for brown patch and gray leaf spot to explode. If you know a storm system is moving through, delay fertilizing and consider a preventative fungicide application if your lawn has a history of disease problems.</p>
+        </div>
+
+        <h2>Integrated Pest Management (IPM) for Louisiana Lawns</h2>
+        <p>Integrated Pest Management is a strategy that focuses on prevention, monitoring, and targeted treatment rather than automatic chemical applications. The goal is to manage pests and diseases with the least possible disruption to the environment and your lawn's natural defenses. Here is how to apply IPM principles to your River Parishes lawn.</p>
+
+        <h3>Prevention Before Treatment</h3>
+        <p>The most effective pest control is a healthy lawn. Grass that is properly mowed, watered, and fertilized can tolerate pest pressure that would devastate a stressed lawn. Focus on building strong root systems through deep, infrequent watering and proper mowing heights. A dense turf canopy also shades the soil, reducing moisture evaporation and making it harder for weed seeds to germinate.</p>
+
+        <h3>Proper Watering</h3>
+        <p>Water deeply but only when the lawn needs it. In the River Parishes, this typically means 1 to 1.5 inches of water per week during the growing season, including rainfall. Watering in the early morning (between 4 AM and 8 AM) is critical — it allows leaf blades to dry during the day, reducing the time that fungal spores have to germinate on wet foliage. Evening watering keeps grass wet overnight, which is an open invitation for brown patch, gray leaf spot, and other diseases. Follow our <a href="blog-watering-guide.html">complete watering guide</a> for a schedule tailored to Louisiana's climate.</p>
+
+        <h3>Mowing Height and Frequency</h3>
+        <p>Scalping your lawn is one of the quickest ways to invite pest and disease problems. St. Augustine should be mowed at 3 to 4 inches. Taller grass develops deeper roots, shades out weeds, and recovers faster from insect feeding. Never remove more than one-third of the leaf blade in a single mowing. During peak growing season, this may mean mowing every 5 to 7 days. Keep mower blades sharp — dull blades tear the grass, creating ragged wounds where disease spores can enter. For specific height recommendations by grass type, see our <a href="blog-mowing-height-guide.html">mowing height guide</a>.</p>
+
+        <h3>Air Circulation</h3>
+        <p>Good airflow across your lawn reduces humidity at the grass canopy level, which directly suppresses fungal disease. Trim back overgrown shrubs, thin dense tree canopies, and keep landscape beds clean. In shaded areas where air movement is limited, consider pruning lower branches to allow more breeze and light penetration. Poor air circulation combined with heavy shade creates a microclimate where disease thrives year-round.</p>
+
+        <div class="tip-box">
+          <p><strong>IPM rule of thumb:</strong> Before applying any chemical treatment, confirm the pest or disease is actually present and at damaging levels. Many brown patches are caused by overwatering or compacted soil, not fungus. Treat the cause, not the symptom.</p>
+        </div>
+
+        <h2>Treatment Options</h2>
+        <p>When prevention and cultural practices are not enough, targeted chemical treatments can bring a lawn back from serious pest or disease pressure. Below is an overview of the most common and effective product types available for Louisiana lawns.</p>
+
+        <h3>Insecticide Types</h3>
+        <p><strong>Pyrethroids</strong> (bifenthrin, lambda-cyhalothrin, permethrin) are fast-acting contact insecticides that work well for surface-feeding pests like armyworms and sod webworms. They break down quickly in sunlight and are generally safe for established lawns when applied according to label directions. Pyrethroids provide quick knockdown but limited residual control — expect 2 to 4 weeks of protection.</p>
+        <p><strong>Neonicotinoids</strong> (imidacloprid, clothianidin, thiamethoxam) are systemic insecticides that are absorbed by the plant and provide longer residual control, typically 6 to 8 weeks. They are particularly effective against chinch bugs and white grubs because the insect ingests the chemical when feeding on plant tissue. Neonicotinoids are best applied preventatively or at the first sign of infestation. Follow label instructions carefully regarding timing — application during blooming periods can affect pollinators.</p>
+
+        <h3>Fungicide Types</h3>
+        <p><strong>Contact fungicides</strong> (chlorothalonil, mancozeb) remain on the surface of leaf blades and kill fungal spores before they can infect the plant. They provide protective cover but do not cure existing infections. Contact fungicides wash off with rain or irrigation and need reapplication every 7 to 14 days during active disease periods.</p>
+        <p><strong>Systemic fungicides</strong> (azoxystrobin, propiconazole, tebuconazole, thiophanate-methyl) are absorbed into plant tissue and provide both curative and protective activity. They move through the plant's vascular system and can stop an active infection from spreading. Systemic fungicides last 14 to 28 days depending on the product and weather conditions. Many professionals use a rotation of systemic products with different modes of action to prevent fungal resistance.</p>
+
+        <h3>Application Timing</h3>
+        <p>Timing is everything in lawn pest and disease management. Preventative applications — applied before the pest or disease appears — are far more effective than curative treatments applied after damage is visible. Here is a seasonal timing guide for the River Parishes:</p>
+        <ul>
+          <li><strong>Early spring (March-April):</strong> Pre-emergent herbicide for summer weeds; preventative grub control if you had issues the previous year.</li>
+          <li><strong>Late spring (May-June):</strong> Monitor for chinch bugs as temperatures rise. Apply systemic insecticide at first detection. Preventative fungicide if your lawn has a history of brown patch.</li>
+          <li><strong>Summer (July-August):</strong> Peak chinch bug and armyworm season. Treat immediately upon confirmation. Contact fungicides for active disease outbreaks.</li>
+          <li><strong>Early fall (September-October):</strong> Armyworm watch continues. Preventative large patch fungicide application for St. Augustine going into winter.</li>
+          <li><strong>Late fall (November):</strong> Grub treatment if thresholds are exceeded. Final fungicide application before winter dormancy if large patch has been a recurring problem.</li>
+        </ul>
+
+        <h2>When to Call a Professional vs DIY</h2>
+        <p>Many lawn pest and disease problems can be managed by an informed homeowner, but there are clear situations where professional help is the smarter and more cost-effective choice. Here is how to decide.</p>
+
+        <p><strong>You can handle it yourself when:</strong> The problem is limited to a small area, you have correctly identified the pest or disease, and you are comfortable following label directions for the appropriate product. Spot-treating a small chinch bug patch or applying a contact fungicide after a summer storm are well within the range of a diligent DIY approach. Always wear proper protective equipment and keep children and pets off treated areas until the product has dried completely.</p>
+
+        <p><strong>Call a professional when:</strong> The damage covers more than 30 percent of your lawn, you have tried DIY treatment without success, the problem returns every year despite your efforts, or you cannot confidently identify what is causing the damage. Professionals have access to commercial-grade products, application equipment that delivers better coverage, and the experience to diagnose subtle problems that mimic each other. A professional <a href="blog-fertilizing-guide.html">fertilization and pest control program</a> is often more cost-effective than repeated trial-and-error purchases of retail products.</p>
+
+        <div class="warning-box">
+          <p><strong>Professional tip:</strong> If skunks or armadillos are digging up your lawn, do not trap the animals until you treat the grub problem they are feeding on. Remove the food source (grubs) with a targeted insecticide application, and the digging will stop on its own. Trapping without treating the underlying pest is a temporary fix.</p>
+        </div>
+
+        <h2>Louisiana-Specific Pest and Disease Pressure</h2>
+        <p>Louisiana's River Parishes region — including LaPlace, Reserve, Garyville, and surrounding communities — has a unique combination of climate, soil, and grass preferences that shapes pest and disease pressure in ways you will not see in other parts of the country.</p>
+
+        <p><strong>Chinch bugs are the #1 St. Augustine killer in the River Parishes.</strong> The hot, humid summers combined with the popularity of St. Augustine grass create ideal conditions for chinch bug populations to explode. Every summer, we see lawns that have been completely destroyed by undetected chinch bug infestations. The damage is often mistaken for drought stress, leading homeowners to water more — which only compounds the problem by keeping the lawn wet and stressed. If you have St. Augustine grass in LaPlace or the surrounding River Parishes, regular chinch bug inspection from June through August is not optional; it is essential lawn care.</p>
+
+        <p><strong>Brown patch after summer storms.</strong> The Gulf Coast thunderstorm pattern in July and August creates a perfect storm for fungal disease. Afternoon storms drop heavy rain, followed by warm, humid nights with temperatures staying above 80°F. This is brown patch weather. The fungus can go from invisible to destroying a large section of lawn in 48 to 72 hours. Homeowners should inspect their lawns after every heavy rain event and be ready to apply a contact fungicide at the first sign of circular patches.</p>
+
+        <p><strong>Armyworm outbreaks after wet springs.</strong> When the River Parishes have a wet spring, armyworm moth populations surge, and the resulting caterpillar outbreaks in late summer can be devastating. We recommend keeping a close eye on your lawn in August and September, especially if you had a rainy spring. Birds congregating on your lawn early in the morning are often the first sign that armyworms are present and feeding.</p>
+
+        <p>For year-round protection, combining proper <a href="blog-mowing-height-guide.html">mowing practices</a> with a smart <a href="blog-watering-guide.html">watering schedule</a> and an appropriate <a href="blog-fertilizing-guide.html">fertilization program</a> creates a lawn that can resist most pest and disease pressure on its own.</p>
+
+        <div class="cta-box">
+          <h3>Need Professional Pest or Disease Control?</h3>
+          <p>If you have recurring lawn damage, or you just want peace of mind with regular inspections and preventative treatments, our team knows the River Parishes pest and disease patterns inside out. We offer free lawn inspections and customized treatment plans.</p>
+          <a class="cta-btn" href="/static/home.html#waitlist">Request a Free Lawn Inspection</a>
+          <p style="margin-top: 0.5rem; font-size: 0.9rem;">Serving LaPlace, Reserve, Garyville, and all River Parishes communities</p>
+        </div>
+
+        <div class="related">
+          <h2>Related reading</h2>
+          <ul>
+            <li><a href="blog-mowing-height-guide.html">Mowing Height Guide — How Tall to Cut Your Louisiana Lawn</a></li>
+            <li><a href="blog-watering-guide.html">Watering Guide — When and How Much to Water in South Louisiana</a></li>
+            <li><a href="blog-weed-control-guide.html">Weed Control Guide — Managing Unwanted Plants in Your Lawn</a></li>
+          </ul>
+        </div>
+        <a class="backlink" href="/blog">← Back to the South Louisiana Blog Hub</a>
+      </article>
+    </main>
+  </body>
+</html>

--- a/web/static/blog-seasonal-tips.html
+++ b/web/static/blog-seasonal-tips.html
@@ -582,6 +582,23 @@
           </p>
           <a href="home.html#waitlist" class="btn">Get a Free Quote →</a>
         </div>
+    <div class="related-posts">
+      <h3 style="color:#1f2937; margin-bottom: 1rem; font-size: 1.25rem;">📚 Related Guides</h3>
+      <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem;">
+        <a href="blog-grass-types.html" style="display: block; padding: 1rem; background: #f9fafb; border-radius: 10px; text-decoration: none; color: #374151; border: 1px solid #e5e7eb;">
+          <strong style="color: #10b981;">🌿</strong>
+          <span style="font-size: 0.9rem;">Best Grass Types for LaPlace</span>
+        </a>
+        <a href="blog-watering-guide.html" style="display: block; padding: 1rem; background: #f9fafb; border-radius: 10px; text-decoration: none; color: #374151; border: 1px solid #e5e7eb;">
+          <strong style="color: #10b981;">💧</strong>
+          <span style="font-size: 0.9rem;">Louisiana Lawn Watering Guide</span>
+        </a>
+        <a href="blog-storm-recovery-guide.html" style="display: block; padding: 1rem; background: #f9fafb; border-radius: 10px; text-decoration: none; color: #374151; border: 1px solid #e5e7eb;">
+          <strong style="color: #10b981;">⛈️</strong>
+          <span style="font-size: 0.9rem;">Storm Recovery Guide</span>
+        </a>
+      </div>
+    </div>
 
         <a href="home.html#blog" class="back-link">← Back to All Articles</a>
       </article>

--- a/web/static/blog-shade-drainage-guide.html
+++ b/web/static/blog-shade-drainage-guide.html
@@ -1,0 +1,506 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Shade, Drainage, and Tree Competition in Louisiana Lawns | Xcellent1 Lawn Care Blog</title>
+    <meta name="description" content="Complete guide to fixing shade problems, drainage issues, tree root competition, and soil compaction in South Louisiana lawns. Expert solutions for the River Parishes." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://xcellent1lawncare.com/blog-shade-drainage-guide" />
+    <meta property="og:title" content="Shade, Drainage, and Tree Competition in Louisiana Lawns" />
+    <meta property="og:description" content="Complete guide to fixing shade problems, drainage issues, tree root competition, and soil compaction in South Louisiana lawns." />
+    <meta property="og:image" content="https://xcellent1lawncare.com/images/flowerbedcleanup.webp" />
+    <meta property="article:published_time" content="2026-01-03" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Shade, Drainage, and Tree Competition in Louisiana Lawns" />
+    <meta name="twitter:description" content="Fix the problems that kill lawns in South Louisiana: shade, drainage, tree roots, and compacted soil." />
+    <link rel="canonical" href="https://xcellent1lawncare.com/blog-shade-drainage-guide" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon.ico" />
+    <link rel="stylesheet" href="styles.clean.css" />
+    <meta name="theme-color" content="#3b832a" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "Shade, Drainage, and Tree Competition in Louisiana Lawns",
+        "description": "Complete guide to fixing shade problems, drainage issues, tree root competition, and soil compaction in South Louisiana lawns.",
+        "author": { "@type": "Organization", "name": "Xcellent1 Lawn Care" },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Xcellent1 Lawn Care"
+        },
+        "datePublished": "2026-01-03",
+        "dateModified": "2026-06-16",
+        "mainEntityOfPage": {
+          "@type": "WebPage",
+          "@id": "https://xcellent1lawncare.com/blog-shade-drainage-guide"
+        }
+      }
+    </script>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      body { font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; background: #f8fafc; }
+      .navbar {
+        display: flex; align-items: center; justify-content: space-between;
+        padding: 0.75rem 2rem; background: rgba(1, 39, 20, 0.98);
+        position: sticky; top: 0; z-index: 100;
+      }
+      .navbar-brand { display: flex; align-items: center; gap: 0.75rem; }
+      .navbar-logo { height: 44px; width: auto; }
+      .navbar-title { display: flex; flex-direction: column; line-height: 1.2; }
+      .navbar-name { font-size: 1.1rem; font-weight: 800; color: #22c55e; letter-spacing: 2px; }
+      .navbar-tagline { font-size: 0.65rem; color: #86efac; letter-spacing: 3px; text-transform: uppercase; }
+      .navbar-links { display: flex; align-items: center; gap: 1.5rem; }
+      .navbar-link { color: #d1fae5; text-decoration: none; font-weight: 500; font-size: 0.9rem; transition: color 0.2s; }
+      .navbar-link:hover { color: #22c55e; }
+      .navbar-login {
+        background: #22c55e; color: #012714; padding: 0.5rem 1.25rem;
+        border-radius: 8px; text-decoration: none; font-weight: 700; font-size: 0.85rem;
+        transition: background 0.2s;
+      }
+      .navbar-login:hover { background: #16a34a; }
+      .blog-hero {
+        background: linear-gradient(135deg, rgba(59, 131, 42, 0.92), rgba(19, 63, 28, 0.96)), url("/images/flowerbedcleanup.webp") center/cover;
+        padding: 5rem 1rem;
+        text-align: center;
+        color: #fff;
+      }
+      .blog-hero h1 {
+        font-size: clamp(2rem, 4vw, 3.2rem);
+        margin-bottom: 0.75rem;
+        font-weight: 800;
+        text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+      }
+      .blog-hero .meta {
+        font-size: 0.95rem;
+        opacity: 0.95;
+        display: flex;
+        justify-content: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+      .reading-time {
+        background: rgba(255, 255, 255, 0.2);
+        padding: 0.25rem 0.75rem;
+        border-radius: 20px;
+        font-size: 0.85rem;
+      }
+      .blog-container {
+        max-width: 860px;
+        margin: -3rem auto 0;
+        padding: 0 1rem 2rem;
+        position: relative;
+        z-index: 10;
+      }
+      .blog-content {
+        background: #fff;
+        border-radius: 16px;
+        padding: 2.5rem;
+        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
+      }
+      .blog-content > p:first-of-type {
+        font-size: 1.15rem;
+        color: #4b5563;
+        line-height: 1.8;
+      }
+      .blog-content h2 {
+        color: #166534;
+        margin: 2.5rem 0 1rem;
+        font-size: 1.5rem;
+        position: relative;
+        padding-bottom: 0.5rem;
+      }
+      .blog-content h2::after {
+        content: "";
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 60px;
+        height: 3px;
+        background: linear-gradient(90deg, #22c55e, #3b832a);
+        border-radius: 2px;
+      }
+      .blog-content h3 {
+        color: #075985;
+        margin: 1.75rem 0 0.75rem;
+        font-size: 1.2rem;
+      }
+      .blog-content p, .blog-content li {
+        line-height: 1.8;
+        color: #374151;
+        font-size: 1.02rem;
+      }
+      .blog-content p { margin-bottom: 1rem; }
+      .blog-content ul, .blog-content ol {
+        margin: 0.75rem 0 1.5rem;
+        padding-left: 1.25rem;
+      }
+      .blog-content li { margin-bottom: 0.4rem; }
+      .blog-content a { color: #166534; font-weight: 600; }
+      .infobox {
+        background: #f0fdf4;
+        border-left: 4px solid #22c55e;
+        border-radius: 0 12px 12px 0;
+        padding: 1.25rem 1.5rem;
+        margin: 1.5rem 0;
+      }
+      .infobox h4 { color: #14532d; margin-bottom: 0.5rem; font-size: 1rem; }
+      .infobox p, .infobox li { color: #14532d; margin-bottom: 0.25rem; }
+      .infobox ul { margin: 0.25rem 0 0 1rem; }
+      .warnbox {
+        background: #fef2f2;
+        border-left: 4px solid #ef4444;
+        border-radius: 0 12px 12px 0;
+        padding: 1.25rem 1.5rem;
+        margin: 1.5rem 0;
+      }
+      .warnbox h4 { color: #991b1b; margin-bottom: 0.5rem; font-size: 1rem; }
+      .warnbox p { color: #7f1d1d; }
+      .solbox {
+        background: #f0f9ff;
+        border-left: 4px solid #0ea5e9;
+        border-radius: 0 12px 12px 0;
+        padding: 1.25rem 1.5rem;
+        margin: 1.5rem 0;
+      }
+      .solbox h4 { color: #0c4a6e; margin-bottom: 0.5rem; font-size: 1rem; }
+      .solbox p, .solbox li { color: #0c4a6e; }
+      .solbox ul { margin: 0.25rem 0 0 1rem; }
+      .grass-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1.5rem 0;
+        font-size: 0.95rem;
+      }
+      .grass-table th {
+        background: #166534;
+        color: #fff;
+        padding: 0.75rem 1rem;
+        text-align: left;
+      }
+      .grass-table td {
+        padding: 0.65rem 1rem;
+        border-bottom: 1px solid #e5e7eb;
+      }
+      .grass-table tr:nth-child(even) td { background: #f0fdf4; }
+      .grass-table tr:hover td { background: #dcfce7; }
+      .cta-section {
+        background: linear-gradient(135deg, #3b832a 0%, #10b981 100%);
+        border-radius: 16px;
+        padding: 2.5rem;
+        text-align: center;
+        margin: 3rem 0 2rem;
+      }
+      .cta-section h3 {
+        color: #fff;
+        margin: 0 0 0.75rem;
+        font-size: 1.75rem;
+      }
+      .cta-section p {
+        color: rgba(255, 255, 255, 0.9);
+        margin: 0 0 1.5rem;
+        font-size: 1.1rem;
+      }
+      .cta-section .btn {
+        background: #fff;
+        color: #10b981;
+        padding: 0.875rem 2.5rem;
+        border-radius: 10px;
+        font-weight: 600;
+        text-decoration: none;
+        display: inline-block;
+        transition: all 0.2s;
+        font-size: 1.05rem;
+      }
+      .cta-section .btn:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+      }
+      .related {
+        border-top: 1px solid #e5e7eb;
+        margin-top: 2rem;
+        padding-top: 1.5rem;
+      }
+      .related h2 { margin-top: 0; }
+      .related a { color: #166534; text-decoration: none; font-weight: 700; }
+      .related a:hover { text-decoration: underline; }
+      .backlink {
+        display: inline-block;
+        margin-top: 1.5rem;
+        color: #166534;
+        font-weight: 700;
+        text-decoration: none;
+      }
+      .backlink:hover { text-decoration: underline; }
+      .blog-footer {
+        background: rgba(1, 39, 20, 0.98);
+        color: #fff;
+        text-align: center;
+        padding: 2.5rem 1rem;
+        margin-top: 3rem;
+      }
+      @media (max-width: 768px) {
+        .navbar { padding: 0.5rem 1rem; flex-wrap: wrap; gap: 0.5rem; }
+        .navbar-links { gap: 0.75rem; }
+        .blog-hero { padding: 4rem 1rem 2.5rem; }
+        .blog-content { padding: 1.35rem; }
+        .cta-section { padding: 1.5rem; }
+        .grass-table { font-size: 0.85rem; }
+        .grass-table th, .grass-table td { padding: 0.5rem; }
+      }
+    </style>
+  </head>
+  <body>
+    <nav class="navbar">
+      <div class="navbar-brand">
+        <img src="images/xcellent1-logo-transparent.png" alt="Xcellent1 logo" class="navbar-logo" />
+        <div class="navbar-title">
+          <span class="navbar-name">XCELLENT1</span>
+          <span class="navbar-tagline">LAWN CARE</span>
+        </div>
+      </div>
+      <div class="navbar-links">
+        <a href="home.html" class="navbar-link">Home</a>
+        <a href="shop.html" class="navbar-link">Shop</a>
+        <a href="careers.html" class="navbar-link">Careers</a>
+        <a href="login.html" class="navbar-login">Login</a>
+      </div>
+    </nav>
+
+    <header class="blog-hero">
+      <div class="blog-container">
+        <h1>Shade, Drainage, and Tree Competition in Louisiana Lawns</h1>
+        <div class="meta">
+          <span>📅 2026-01-03</span>
+          <span class="reading-time">📖 12 min read</span>
+          <span>Site conditions · South Louisiana</span>
+        </div>
+      </div>
+    </header>
+
+    <main class="blog-container">
+      <article class="blog-content">
+        <p>Some lawns do not fail because the grass is wrong. They fail because the site is fighting the grass every day. Shade, drainage, tree roots, and compacted soil are often the real story. In South Louisiana, our unique combination of heavy clay soils, dense tree canopies, and high rainfall creates perfect conditions for these problems. Understanding how to diagnose and correct each issue is the key to a lawn that thrives year-round.</p>
+
+        <p>This guide covers everything from Louisiana's most troublesome shade trees to French drains, rain gardens, and the best ground covers for deep shade. Whether you are dealing with a soggy backyard near the river, a front lawn buried under live oaks, or compacted soil from years of foot traffic, you will find practical solutions you can implement yourself or with professional help.</p>
+
+        <h2>How Much Shade Is Too Much?</h2>
+        <p>Not all shade is created equal. Light shade (dappled sunlight through a single tree) is manageable for most warm-season grasses. Dense shade under a broad-canopy live oak or a cluster of pecans can reduce light levels so low that no turfgrass will survive. The general rule: if an area receives fewer than four hours of direct sunlight per day, grass will struggle to maintain density regardless of species.</p>
+
+        <p>Louisiana's most common shade culprits include live oaks, pecan trees, southern magnolias, and water oaks. Live oaks in particular cast extremely dense shade because their evergreen canopy persists year-round. Unlike deciduous trees that let sunlight through in winter, live oaks block light every day of the year, creating a persistent low-light environment beneath them.</p>
+
+        <div class="infobox">
+          <h4>Quick Shade Test</h4>
+          <p>On a sunny day, measure sunlight in suspected problem areas using a simple light meter or even a smartphone app. Mark spots that get less than 4 hours of direct sun. Those zones will need either the most shade-tolerant grass, a ground cover alternative, or canopy reduction to support turf.</p>
+        </div>
+
+        <h3>Grass Types and Shade Tolerance</h3>
+        <p>Selecting the right grass for your light conditions is the single most important decision you can make for a shaded lawn. Here is how the major warm-season grasses stack up:</p>
+
+        <table class="grass-table">
+          <thead>
+            <tr>
+              <th>Grass Type</th>
+              <th>Shade Tolerance</th>
+              <th>Minimum Sun</th>
+              <th>Best For</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>St. Augustine</td>
+              <td>Excellent</td>
+              <td>4-5 hours</td>
+              <td>Moderate to dense shade; most shade-tolerant warm-season grass</td>
+            </tr>
+            <tr>
+              <td>Zoysia</td>
+              <td>Moderate</td>
+              <td>5-6 hours</td>
+              <td>Light to moderate shade; good where St. Augustine is not desired</td>
+            </tr>
+            <tr>
+              <td>Centipede</td>
+              <td>Low to Moderate</td>
+              <td>6+ hours</td>
+              <td>Open shade with some direct sun; not for deep shade</td>
+            </tr>
+            <tr>
+              <td>Bermuda</td>
+              <td>Poor</td>
+              <td>8+ hours</td>
+              <td>Full sun only; will thin and die in any significant shade</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p><strong>St. Augustine</strong> is the clear winner for Louisiana lawns with shade problems. Varieties like Palmetto and Raleigh have been bred specifically for improved shade tolerance. If you have mature trees shading large portions of your yard, St. Augustine is almost always the right choice. <strong>Zoysia</strong> (especially Emerald or Empire) offers a respectable middle ground, performing well in light shade but thinning under dense canopies. <strong>Bermuda grass</strong> should never be planted in a shaded area — it requires full, direct sun for at least eight hours daily and will deteriorate quickly under trees.</p>
+
+        <p>For a detailed comparison of each grass type's maintenance needs and ideal growing conditions, see our <a href="blog-grass-types.html">complete guide to grass types for Louisiana lawns</a>.</p>
+
+        <h2>Drainage Problems in Louisiana Lawns</h2>
+        <p>Poor drainage is one of the most widespread lawn issues in the River Parishes. Louisiana's soil is dominated by heavy clay — the same "gumbo" soil that makes the region so fertile also creates serious drainage challenges. Clay particles are microscopically small and pack tightly together, leaving little pore space for water to move through. After a heavy rain, clay soil can remain saturated for days.</p>
+
+        <h3>Signs of Poor Drainage</h3>
+        <ul>
+          <li><strong>Standing water</strong> that lingers for 24 hours or more after rain.</li>
+          <li><strong>Moss or algae growth</strong> on the soil surface, especially in low areas.</li>
+          <li><strong>Yellowing grass</strong> in patches, often mistaken for a fertilizer deficiency when the real cause is waterlogged roots.</li>
+          <li><strong>Spongy feel</strong> when walking across the lawn, indicating the soil is saturated near the surface.</li>
+          <li><strong>Thin or dead grass</strong> in low spots that collect runoff from downspouts or higher ground.</li>
+          <li><strong>Mosquito activity</strong> — standing water breeds mosquitoes, so a sudden increase is a drainage red flag.</li>
+          <li><strong>Rust-colored or gray soil</strong> mottling, a sign that the soil has been waterlogged long enough to create anaerobic conditions.</li>
+        </ul>
+
+        <p>Many homeowners compound drainage problems by overwatering to compensate for thin turf. If your lawn stays wet after rain and the grass looks weak, the first step is always fixing the water movement — not adding more water or fertilizer.</p>
+
+        <div class="warnbox">
+          <h4>Do Not Fertilize a Waterlogged Lawn</h4>
+          <p>Applying fertilizer to saturated soil is counterproductive. The nutrients either run off into drains (wasting money and polluting waterways) or sit in anaerobic soil where grass roots cannot absorb them. Fix the drainage first, then feed the lawn.</p>
+        </div>
+
+        <h2>Solutions for Shade Problems</h2>
+
+        <h3>Tree Pruning and Canopy Management</h3>
+        <p>Before you give up on grass under trees, evaluate whether the canopy can be thinned. Selective pruning to elevate the canopy — removing lower branches up to 8-10 feet — can dramatically increase light penetration while preserving the tree's health and appearance. Crown thinning (removing select interior branches) lets more dappled light reach the ground without changing the tree's overall shape.</p>
+
+        <p>For live oaks and pecans, work with an ISA-certified arborist who understands the species. Live oaks are sensitive to over-pruning, and pecan trees have specific structural needs. A good pruning job can add 1-2 hours of usable light to the understory, which is often enough to make St. Augustine viable.</p>
+
+        <div class="solbox">
+          <h4>Pruning Best Practices</h4>
+          <ul>
+            <li>Never remove more than 25% of a tree's live canopy in a single season.</li>
+            <li>Focus on the south and west sides of the tree first — that is where the most sunlight comes from.</li>
+            <li>Remove low-hanging limbs that block morning and afternoon sun.</li>
+            <li>Thin the crown gradually over two or three years for large live oaks.</li>
+            <li>Work with a licensed arborist for any tree over 20 feet tall.</li>
+          </ul>
+        </div>
+
+        <h3>Shade-Tolerant Ground Covers</h3>
+        <p>In areas where grass simply will not grow — under dense live oak canopies, between tree roots, or on the north side of a house — switching to a shade-tolerant ground cover is the smartest long-term solution. These plants thrive in low light and require far less maintenance than struggling turf.</p>
+
+        <ul>
+          <li><strong>Mondo grass</strong> (Ophiopogon japonicus): A grass-like perennial that forms a dense, low-growing carpet in full to partial shade. It spreads slowly but steadily and needs mowing only once or twice a year. Excellent under live oaks.</li>
+          <li><strong>Liriope</strong> (Liriope muscari): Also called monkey grass or border grass, liriope grows in clumps 12-18 inches tall and spreads via rhizomes. It tolerates deep shade, drought, and poor soil once established. Use the spreading variety for ground cover and the clumping variety for edging.</li>
+          <li><strong>Asiatic jasmine</strong> (Trachelospermum asiaticum): A low-growing vine that forms a dense, weed-suppressing mat. It is the most durable ground cover for Louisiana shade — it handles foot traffic, resists pests, and stays green year-round. Ideal for large areas under trees where nothing else will grow.</li>
+        </ul>
+
+        <h3>Mulched Beds Under Dense Trees</h3>
+        <p>When the shade is so deep that even ground covers struggle, a mulched bed is the best option. Creating a ring of pine bark or hardwood mulch around the base of large trees accomplishes several things at once: it eliminates the maintenance nightmare of trying to grow grass in impossible conditions, protects the tree's root system from lawn equipment damage, and creates a clean, intentional landscape feature.</p>
+
+        <p>Extend the bed out to the drip line of the tree (the outermost reach of the branches) and edge it cleanly against the lawn. Use 3-4 inches of mulch and refresh it annually. Add shade-tolerant shrubs like aucuba, camellia, or sasanqua for vertical interest, and edge the bed with liriope or mondo grass for a finished look.</p>
+
+        <h2>Solutions for Drainage Issues</h2>
+
+        <h3>French Drains</h3>
+        <p>A French drain is a trench filled with gravel and a perforated pipe that redirects surface and subsurface water away from problem areas. In Louisiana's flat lots, French drains are often the most effective solution for persistent standing water. The drain is installed at a slight slope (1% grade, or about 1 inch of drop per 8 feet) so gravity carries water to a discharge point — typically a ditch, dry well, or storm drain.</p>
+
+        <p>French drains work best when the problem area is a defined low spot or a zone where water collects along a foundation or fence line. For larger yards with broad drainage issues, a curtain drain (a French drain installed along the uphill perimeter of the property) can intercept water before it reaches the lawn.</p>
+
+        <div class="infobox">
+          <h4>French Drain Sizing</h4>
+          <p>For most residential Louisiana lots, a 4-inch perforated PVC or corrugated pipe wrapped in filter fabric is sufficient. The trench should be 12-18 inches wide and 18-24 inches deep, filled with washed gravel to within 4 inches of the surface, then topped with soil or sod. Always call 811 to mark utilities before digging.</p>
+        </div>
+
+        <h3>Dry Wells</h3>
+        <p>A dry well is a subsurface pit (typically 3-5 feet deep and 3-4 feet in diameter) filled with gravel or a prefabricated plastic chamber. It collects stormwater runoff from downspouts, French drains, or low areas and allows it to percolate slowly into the surrounding soil. Dry wells work best in sandy or loamy soils. In heavy clay, they still provide benefit by holding water and releasing it slowly, but the infiltration rate will be slower, so size the pit generously.</p>
+
+        <h3>Rain Gardens</h3>
+        <p>A rain garden is a shallow, planted depression designed to capture and absorb rainwater runoff from roofs, driveways, and lawns. Unlike a French drain that moves water away, a rain garden holds water temporarily (usually 12-48 hours) and allows it to soak in. Native Louisiana plants like swamp sunflower, Virginia iris, cardinal flower, and soft rush thrive in these conditions and create a beautiful, pollinator-friendly landscape feature.</p>
+
+        <p>Site the rain garden at least 10 feet from the foundation and place it where water naturally flows. The garden should be about 4-6 inches deep with a level bottom. Amend the excavated soil with 50% compost to improve absorption. Rain gardens are particularly effective paired with a French drain — the drain collects water and deposits it into the garden for slow infiltration.</p>
+
+        <h3>Soil Amendment with Compost</h3>
+        <p>For broad, shallow drainage problems (not standing water, but slow-draining soil across the whole lawn), incorporating organic matter is the most practical fix. Top-dressing with 1/2 to 1 inch of well-decomposed compost each spring and fall gradually improves soil structure, creating pore spaces for water to move through and roots to penetrate. This is a long-term strategy — visible results take 2-3 seasons — but it addresses the underlying soil condition rather than just managing symptoms.</p>
+
+        <h3>Core Aeration</h3>
+        <p>Aeration mechanically removes plugs of soil (about 2-3 inches long and finger-width) from the lawn, creating channels for water, air, and nutrients to reach the root zone. It is one of the most effective treatments for compacted clay soil in Louisiana lawns. The aeration holes fill in naturally over a few weeks as the soil expands and contracts with wet-dry cycles, leaving a looser, healthier soil profile behind.</p>
+
+        <p>For the best results, aerate in <strong>early spring (March-April)</strong> and again in <strong>early fall (September-October)</strong>. These are the active growing periods for warm-season grasses, so they recover quickly from the disruption. Avoid aerating in the heat of summer or during drought — the stress on the grass is too high. Follow aeration with a top-dressing of compost to supercharge the benefits.</p>
+
+        <h2>Tree Root Competition</h2>
+        <p>Large trees create problems beyond shade. Their root systems — especially those of live oaks, pecans, and water oaks — spread far beyond the canopy drip line and aggressively compete with turf for water and nutrients. In Louisiana's clay soils, these roots often grow near the surface because deeper soil layers are compacted or poorly aerated, making the competition even more intense.</p>
+
+        <h3>Surface Roots</h3>
+        <p>Surface roots are a common sight under Louisiana's mature trees. They make mowing difficult, create tripping hazards, and rob the grass directly around them of moisture. Never cut or shave surface roots — doing so can destabilize the tree and open wounds to disease. Instead, work around them by raising the mower height in those areas or converting the zone to a mulched bed.</p>
+
+        <h3>Encouraging Deeper Root Growth</h3>
+        <p>One of the most effective strategies for reducing root competition is watering deeply and less frequently. Shallow, frequent watering encourages both tree roots and grass roots to stay near the surface, intensifying competition. Deep watering (1 inch of water applied slowly over several hours, penetrating 6-8 inches into the soil) encourages grass roots to grow deeper, where they access moisture that tree roots have not yet reached.</p>
+
+        <p>For guidance on proper watering depth and frequency in Louisiana's climate, see our <a href="blog-watering-guide.html">complete lawn watering guide</a>.</p>
+
+        <h3>Mulching Around Trees</h3>
+        <p>A 2-4 inch layer of organic mulch applied in a ring around the base of trees serves multiple purposes. It conserves soil moisture, moderates soil temperature, suppresses weeds that compete with both the tree and the grass, and slowly adds organic matter as it decomposes. Keep the mulch a few inches away from the trunk itself to prevent bark rot and pest issues.</p>
+
+        <p>The mulched area does not need to be a perfect circle — follow the natural contours of the root zone and blend it into the surrounding landscape. Over time, you can expand the ring as the tree grows, gradually reducing the amount of turf you need to maintain in the root zone.</p>
+
+        <h2>Soil Compaction</h2>
+        <p>Compacted soil is Louisiana's silent lawn killer. Our clay-based soils are naturally prone to compaction, and the combination of foot traffic, lawn equipment, vehicle parking, and children playing can compress the soil particles so tightly that roots cannot penetrate. The result is a lawn that looks thin, feels hard underfoot, and fails to respond to fertilizer and water.</p>
+
+        <h3>Signs of Compacted Soil</h3>
+        <ul>
+          <li>Water pools on the surface instead of soaking in.</li>
+          <li>Grass roots are shallow (less than 2 inches deep when you dig a sample).</li>
+          <li>The soil feels brick-hard when dry.</li>
+          <li>Weeds like goosegrass and annual bluegrass thrive while desirable grass thins out.</li>
+          <li>Lawn mower tires leave deep ruts even on moderately damp soil.</li>
+        </ul>
+
+        <h3>Core Aeration (Mechanical)</h3>
+        <p>Core aeration is the gold standard for relieving compaction. A walk-behind or riding aerator pulls plugs of soil — not spikes, which can actually increase compaction by pressing soil sideways. The plugs should be 2-3 inches long and spaced about 2-4 inches apart. Leave the plugs on the surface to break down naturally and return nutrients to the soil, or rake them up if they look unsightly.</p>
+
+        <p>In Louisiana, the ideal aeration windows are <strong>March through April</strong> (spring green-up) and <strong>September through October</strong> (fall recovery). Aerating twice a year for the first two years will dramatically improve a heavily compacted lawn. After that, once a year (spring or fall) is usually enough for maintenance.</p>
+
+        <h3>Liquid Aeration vs. Mechanical Aeration</h3>
+        <p>Liquid aeration products contain surfactants (wetting agents) and soil conditioners that help break surface tension and improve water penetration. They are sprayed onto the lawn and work by changing the physical properties of the soil to allow better water flow. The advantages: no heavy equipment, no disruption to the lawn surface, and you can treat odd-shaped areas easily.</p>
+
+        <p>However, liquid aeration is significantly less effective than mechanical core aeration on Louisiana's heavy clay soils. The surfactants improve water movement at the surface, but they do not create the physical channels that core aeration provides. For mildly compacted soil or as a maintenance treatment between mechanical aerations, liquid products can help. For severely compacted clay, mechanical aeration is essential.</p>
+
+        <div class="solbox">
+          <h4>Our Recommendation</h4>
+          <p>Use mechanical core aeration for the first 1-2 seasons on compacted clay. Once the soil structure has improved, you can maintain results with an annual liquid aeration treatment in the spring. This combined approach gives you the deep physical correction of mechanical aeration with the convenience of liquid maintenance afterward.</p>
+        </div>
+
+        <h2>Putting It All Together: A Shade-Drainage Action Plan</h2>
+        <p>Most Louisiana lawns with site problems have a combination of issues — not just one. Here is a step-by-step approach to diagnosing and fixing your lawn systematically:</p>
+
+        <ol>
+          <li><strong>Assess sunlight.</strong> Measure hours of direct sun in each zone of your lawn. Map out full-sun, moderate-shade, and deep-shade areas.</li>
+          <li><strong>Identify drainage patterns.</strong> Walk the property after a heavy rain and mark every spot where water stands for more than 12 hours.</li>
+          <li><strong>Check soil compaction.</strong> Try pushing a screwdriver or soil probe into the ground. If it meets hard resistance within 2 inches, you have compaction.</li>
+          <li><strong>Look for tree root competition.</strong> Exposed surface roots and thin grass directly under trees indicate root competition.</li>
+          <li><strong>Pick the right grass.</strong> Use the shade tolerance table above to match each zone to the appropriate grass type. Consider our <a href="blog-grass-types.html">grass types guide</a> for detailed recommendations.</li>
+          <li><strong>Fix drainage first.</strong> Before you invest in new sod or extensive soil amendments, resolve any standing-water issues with drains, grading, or rain gardens.</li>
+          <li><strong>Aerate compacted areas.</strong> Once drainage is corrected, core-aerate the worst spots. Follow with compost top-dressing.</li>
+          <li><strong>Prune trees strategically.</strong> Work with an arborist to thin canopies where possible. Convert deep-shade zones to ground covers or mulched beds.</li>
+          <li><strong>Adjust your watering.</strong> Switch to deep, infrequent watering to encourage deeper roots. See our <a href="blog-watering-guide.html">watering guide</a> for Louisiana-specific schedules.</li>
+        </ol>
+
+        <div class="cta-section">
+          <h3>Need Professional Help?</h3>
+          <p>Every lawn is different. Our team can assess your property's unique shade, drainage, and soil conditions and create a customized plan. No two Louisiana lawns are the same — let us build a solution that works for yours.</p>
+          <a href="home.html#waitlist" class="btn">Get a Free Assessment & Quote</a>
+        </div>
+
+        <div class="related">
+          <h2>Related Reading</h2>
+          <ul>
+            <li><a href="blog-grass-types.html">Best Grass Types for Louisiana Lawns</a> — Choose the right grass for your light conditions</li>
+            <li><a href="blog-watering-guide.html">Louisiana Lawn Watering Guide</a> — Water deeply and less frequently for healthier roots</li>
+            <li><a href="blog-sod-installation-guide.html">Sod Installation Guide</a> — Tips for establishing new sod in challenging conditions</li>
+          </ul>
+        </div>
+
+        <a class="backlink" href="home.html#blog">&larr; Back to All Articles</a>
+      </article>
+    </main>
+
+    <footer class="blog-footer">
+      <p><strong>&copy; 2026 Xcellent1 Lawn Care</strong></p>
+      <p style="font-size: 0.9rem; opacity: 0.8">
+        Serving the River Parishes, Louisiana
+      </p>
+    </footer>
+  </body>
+</html>

--- a/web/static/blog-sod-installation-guide.html
+++ b/web/static/blog-sod-installation-guide.html
@@ -1,0 +1,469 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sod Installation Guide for South Louisiana | Xcellent1 Lawn Care Blog</title>
+    <meta name="description" content="When sod makes sense in Louisiana, how to prep the yard for success, and how to keep new sod alive through the critical first 30 days. Step-by-step guide from Xcellent1." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://xcellent1lawncare.com/blog-sod-installation-guide" />
+    <meta property="og:title" content="Sod Installation Guide for South Louisiana" />
+    <meta property="og:description" content="When sod makes sense in Louisiana, how to prep the yard for success, and how to keep new sod alive through the critical first 30 days. Step-by-step guide from Xcellent1." />
+    <meta property="og:image" content="https://xcellent1lawncare.com/images/product-sod.jpg" />
+    <meta property="article:published_time" content="2025-12-27" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Sod Installation Guide for South Louisiana" />
+    <meta name="twitter:description" content="When sod makes sense in Louisiana, how to prep the yard for success, and how to keep new sod alive through the critical first 30 days." />
+    <link rel="canonical" href="https://xcellent1lawncare.com/blog-sod-installation-guide" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon.ico" />
+    <link rel="stylesheet" href="styles.clean.css" />
+    <meta name="theme-color" content="#3b832a" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "Sod Installation Guide for South Louisiana",
+        "description": "When sod makes sense in Louisiana, how to prep the yard for success, and how to keep new sod alive through the critical first 30 days. Step-by-step guide from Xcellent1.",
+        "author": { "@type": "Organization", "name": "Xcellent1 Lawn Care" },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Xcellent1 Lawn Care"
+        },
+        "datePublished": "2025-12-27",
+        "mainEntityOfPage": {
+          "@id": "https://xcellent1lawncare.com/blog-sod-installation-guide"
+        }
+      }
+    </script>
+    <style>
+      .blog-hero {
+        background: linear-gradient(135deg, rgba(59, 131, 42, 0.92), rgba(19, 63, 28, 0.96)), url("/images/product-sod.jpg") center/cover;
+        padding: 5rem 1rem;
+        text-align: center;
+        color: #fff;
+      }
+      .blog-hero h1 {
+        font-size: clamp(2rem, 4vw, 3.2rem);
+        margin-bottom: 0.75rem;
+        font-weight: 800;
+        text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+      }
+      .blog-hero .meta {
+        font-size: 0.95rem;
+        opacity: 0.95;
+        display: flex;
+        justify-content: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+      .reading-time {
+        background: rgba(255, 255, 255, 0.2);
+        padding: 0.25rem 0.75rem;
+        border-radius: 20px;
+        font-size: 0.85rem;
+      }
+      .blog-container {
+        max-width: 860px;
+        margin: -3rem auto 0;
+        padding: 0 1rem 2rem;
+        position: relative;
+        z-index: 10;
+      }
+      .blog-content {
+        background: #fff;
+        border-radius: 16px;
+        padding: 2.25rem;
+        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
+      }
+      .blog-content > p:first-of-type {
+        font-size: 1.15rem;
+        color: #4b5563;
+        line-height: 1.8;
+      }
+      .blog-content h2 {
+        color: #166534;
+        margin: 2.5rem 0 1rem;
+        font-size: 1.5rem;
+        position: relative;
+        padding-bottom: 0.5rem;
+      }
+      .blog-content h2::after {
+        content: "";
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 60px;
+        height: 3px;
+        background: linear-gradient(90deg, #22c55e, #3b832a);
+        border-radius: 2px;
+      }
+      .blog-content h3 {
+        color: #14532d;
+        margin: 1.75rem 0 0.75rem;
+        font-size: 1.2rem;
+      }
+      .blog-content p, .blog-content li {
+        line-height: 1.8;
+        color: #374151;
+        font-size: 1.02rem;
+      }
+      .blog-content p {
+        margin-bottom: 1rem;
+      }
+      .blog-content ul, .blog-content ol {
+        margin: 0.75rem 0 1.5rem;
+        padding-left: 1.25rem;
+      }
+      .blog-content li {
+        margin-bottom: 0.5rem;
+      }
+      .tip-box {
+        background: linear-gradient(145deg, #f0fdf4 0%, #dcfce7 100%);
+        border-left: 4px solid #22c55e;
+        border-radius: 10px;
+        padding: 1.25rem 1.5rem;
+        margin: 1.5rem 0;
+      }
+      .tip-box strong {
+        color: #166534;
+      }
+      .warning-box {
+        background: linear-gradient(145deg, #fef2f2 0%, #fecaca 100%);
+        border-left: 4px solid #ef4444;
+        border-radius: 10px;
+        padding: 1.25rem 1.5rem;
+        margin: 1.5rem 0;
+      }
+      .warning-box strong {
+        color: #991b1b;
+      }
+      .schedule-box {
+        background: linear-gradient(145deg, #eff6ff 0%, #bfdbfe 100%);
+        border-left: 4px solid #3b82f6;
+        border-radius: 10px;
+        padding: 1.25rem 1.5rem;
+        margin: 1.5rem 0;
+      }
+      .schedule-box h4 {
+        color: #1e40af;
+        margin: 0 0 0.75rem;
+        font-size: 1.05rem;
+      }
+      .schedule-box p {
+        margin-bottom: 0.4rem;
+      }
+      .schedule-box p:last-child {
+        margin-bottom: 0;
+      }
+      .step-card {
+        background: #f9fafb;
+        border: 1px solid #e5e7eb;
+        border-radius: 12px;
+        padding: 1.25rem 1.5rem;
+        margin: 1rem 0;
+      }
+      .step-card .step-number {
+        display: inline-block;
+        background: linear-gradient(135deg, #22c55e, #166534);
+        color: #fff;
+        font-weight: 700;
+        font-size: 0.85rem;
+        padding: 0.2rem 0.7rem;
+        border-radius: 20px;
+        margin-right: 0.5rem;
+      }
+      .step-card h4 {
+        display: inline;
+        color: #1f2937;
+        font-size: 1.1rem;
+      }
+      .step-card p {
+        margin: 0.75rem 0 0;
+      }
+      .step-card ul {
+        margin: 0.5rem 0 0;
+      }
+      .related {
+        border-top: 1px solid #e5e7eb;
+        margin-top: 2rem;
+        padding-top: 1.5rem;
+      }
+      .related h2 {
+        margin-top: 0 !important;
+      }
+      .related a {
+        color: #166534;
+        text-decoration: none;
+        font-weight: 700;
+      }
+      .cta-box {
+        margin-top: 2rem;
+        padding: 1.2rem 1.4rem;
+        border-radius: 14px;
+        background: #f0fdf4;
+        border: 1px solid #bbf7d0;
+      }
+      .cta-box a { color: #14532d; font-weight: 800; }
+      .backlink {
+        display: inline-block;
+        margin-top: 1.5rem;
+        color: #166534;
+        font-weight: 700;
+        text-decoration: none;
+      }
+      .backlink:hover {
+        text-decoration: underline;
+      }
+      .blog-footer {
+        background: rgba(1, 39, 20, 0.98);
+        color: #fff;
+        text-align: center;
+        padding: 2.5rem 1rem;
+        margin-top: 3rem;
+      }
+      @media (max-width: 640px) {
+        .blog-content { padding: 1.35rem; }
+        .blog-hero { padding: 4rem 1rem 2.5rem; }
+      }
+    </style>
+  </head>
+  <body>
+    <header class="blog-hero">
+      <div class="blog-container">
+        <h1>Sod Installation Guide for South Louisiana</h1>
+        <div class="meta">
+          <span>Published: 2025-12-27</span>
+          <span class="reading-time">Read: 12 min</span>
+          <span>Installation &amp; Renovation</span>
+        </div>
+      </div>
+    </header>
+
+    <main class="blog-container">
+      <article class="blog-content">
+        <p>
+          Sod is the fastest way to turn bare ground into a finished, green lawn. In South Louisiana's hot, humid climate, a properly installed sod lawn can look established within weeks instead of the months it takes seed to fill in. But sod is also an investment &mdash; a failed installation means losing both money and time. This guide covers everything from deciding whether sod makes sense for your project to watering schedules, first mow, and long-term care for the River Parishes region.
+        </p>
+
+        <h2>When Sod Makes Sense vs. Seed</h2>
+        <p>
+          In South Louisiana, most warm-season grasses are available as sod, and for good reason. Seeding a lawn from scratch requires daily watering, careful weed management, and several months before the grass can handle foot traffic. Sod gives you an instant lawn that roots in within two to three weeks. But sod is not always the right choice for every situation.
+        </p>
+        <p>
+          <strong>St. Augustine grass</strong> &mdash; the most popular lawn grass across LaPlace, Hammond, and the River Parishes &mdash; <em>must</em> be installed as sod or sprigs. St. Augustine produces very little viable seed, so bagged St. Augustine seed you see online is almost never the real thing. If you want a St. Augustine lawn, sod is your only option. (<a href="/blog-grass-types">Learn more about grass types for Louisiana lawns.</a>)
+        </p>
+        <p>
+          <strong>Bermuda grass</strong> can be planted from seed or installed as sod. Seed is much cheaper and works well for large areas, but it takes six to eight weeks to establish and requires consistent moisture during that period. Sod is significantly faster &mdash; you can walk on it and mow it within two weeks. For homeowners who want a usable lawn quickly or who are dealing with erosion on a slope, Bermuda sod is worth the investment.
+        </p>
+        <p>
+          <strong>Zoysia grass</strong> is available both ways too. Seeded Zoysia is slow to fill in &mdash; expect eight to twelve weeks for a thin stand, and a full season before the lawn is thick. Zoysia sod, on the other hand, establishes in about the same timeframe as Bermuda sod. The denser canopy of Zoysia sod also helps suppress weeds during the establishment period.
+        </p>
+
+        <div class="tip-box">
+          <strong>Quick Decision Guide:</strong> Choose sod when you need a lawn fast (curb appeal before selling, eroding slope, impatient homeowner), when planting St. Augustine (sod required), or when you only have a small area (under 5,000 sq ft). Choose seed when budget is tight, the area is very large, or you are willing to wait two to three months for establishment.
+        </div>
+
+        <h2>Best Time to Install Sod in Louisiana</h2>
+        <p>
+          Timing matters in South Louisiana because extreme heat and humidity make establishment harder. The ideal windows for sod installation are:
+        </p>
+        <ul>
+          <li><strong>March through May</strong> &mdash; Spring installation gives the sod three to four months of good growing weather before the worst summer heat arrives. Soil temperatures are rising, rain is frequent, and the grass roots have time to establish deep before the stress of July and August.</li>
+          <li><strong>September through October</strong> &mdash; Fall is the second-best window. The brutal summer heat has broken, fall rains help keep the sod moist, and the grass has several weeks of active growth before going dormant in winter. Sod installed in September has the whole following spring to strengthen.</li>
+        </ul>
+        <p>
+          <strong>AVOID installing sod in July and August</strong> if you can help it. The combination of 95+ degree heat, intense sun, and high humidity means the sod dries out faster than you can keep up with watering. Even with careful irrigation, August-installed sod has a much higher failure rate. If you absolutely must install during summer, expect to water three to four times daily and accept that some sections may not survive.
+        </p>
+
+        <h2>Site Preparation: The Foundation of Success</h2>
+        <p>
+          The single biggest cause of sod failure in South Louisiana is poor site preparation. Sod laid over compacted clay, weeds, or an ungraded surface will struggle, thin out, and eventually die. Proper prep takes time &mdash; plan for at least two weeks before the sod arrives.
+        </p>
+
+        <h3>Step 1: Kill Existing Vegetation</h3>
+        <p>
+          Everything green on the installation site must go. The most effective approach is a non-selective herbicide containing <strong>glyphosate</strong> (Roundup or a generic equivalent). Apply it to actively growing weeds and grass, then wait the full time listed on the label &mdash; typically 10 to 14 days. The vegetation will turn brown and die. If stubborn weeds or Bermuda grass regrow after the first application, spot-treat and wait another week.
+        </p>
+        <p>
+          Do not skip this step. Tilling live weeds into the soil just replants them, and within weeks they will push through your new sod. Dead vegetation can be left in place as organic matter or raked off before tilling.
+        </p>
+
+        <h3>Step 2: Grade the Soil</h3>
+        <p>
+          The site needs a consistent slope that carries water <strong>away from the house foundation</strong>. In South Louisiana's flat terrain, a minimum slope of 1 to 2 percent (roughly 1/8 inch per foot) is the standard. Use a rake, a leveling bar, or a small tractor-mounted blade to cut high spots and fill low spots.
+        </p>
+        <ul>
+          <li>Remove rocks, roots, and construction debris larger than a golf ball.</li>
+          <li>Fill depressions where water could pool &mdash; standing water will kill sod roots.</li>
+          <li>Compact the fill in low spots with a hand tamper or roller to prevent settling later.</li>
+          <li>Aim for the finished grade to sit 1 inch below sidewalks and driveways so the sod sits flush.</li>
+        </ul>
+
+        <h3>Step 3: Add and Incorporate Soil Amendments</h3>
+        <p>
+          Louisiana native soil is often heavy clay that drains poorly and compacts easily. Adding organic matter improves drainage, aeration, and root penetration.
+        </p>
+        <ul>
+          <li><strong>Spread 2 inches of topsoil or compost</strong> over the entire area. Screened topsoil is ideal; avoid products with large wood chips or bark that tie up nitrogen as they decompose.</li>
+          <li><strong>Till 4 to 6 inches deep</strong> to incorporate the organic matter into the existing soil. A rear-tine tiller works best for breaking up clay. Tilling also removes any remaining weed roots and creates a loose seedbed for sod roots to penetrate.</li>
+          <li><strong>Level and roll.</strong> After tilling, rake the surface smooth, removing any new rocks or debris that surfaced. Then roll the area with a water-filled roller (about half full) to lightly firm the soil. The surface should be solid enough that a footprint sinks no deeper than 1/4 to 1/2 inch. If the soil is too soft, the sod will settle unevenly after the first watering.</li>
+        </ul>
+
+        <h3>Step 4: Soil Test and Fertilizer</h3>
+        <p>
+          A soil test before installation prevents expensive guesswork. In the River Parishes, native soil pH frequently runs below 6.0, which is too acidic for most warm-season grasses. <strong>Target a soil pH of 6.0 to 6.5</strong> for optimal nutrient availability.
+        </p>
+        <ul>
+          <li>Test the soil pH at least four weeks before installation. LSU AgCenter offers affordable soil testing through your local extension office.</li>
+          <li>If pH is below 6.0, apply <strong>pelleted dolomitic lime</strong> at the rate the soil test recommends (typically 40 to 50 pounds per 1,000 sq ft for a 0.5-point pH bump). Water it in and till or rake it into the top 4 inches.</li>
+          <li>Apply a <strong>starter fertilizer high in phosphorus</strong> (the middle number) to encourage strong root development. A 5-20-5 or 10-20-10 blend at the bag rate (usually about 10 pounds per 1,000 sq ft) worked into the top 2 inches of soil gives new sod the phosphorus it needs for root growth.</li>
+          <li>Water the prepared area lightly the day before the sod arrives so the soil is moist but not muddy.</li>
+        </ul>
+
+        <div class="tip-box">
+          <strong>Pro Tip:</strong> Do not apply a weed-and-feed or a nitrogen-only fertilizer before laying sod. High nitrogen without established roots wastes the fertilizer and can burn tender new roots. Stick with a high-phosphorus starter blend.
+        </div>
+
+        <h2>Sod Installation: Step by Step</h2>
+        <p>
+          The sod should be installed the same day it is delivered if possible. Sod left rolled on a pallet for more than 24 hours begins to heat up, break down, and die from the inside out. If you cannot install everything in one day, unroll the pallet and lay the pieces flat in a shady area, keeping them moist.
+        </p>
+
+        <div class="step-card">
+          <span class="step-number">1</span> <h4>Start Along a Straight Edge</h4>
+          <p>Begin laying sod along the longest straight edge of the lawn, typically a driveway, sidewalk, or property line. Butt the first row of sod firmly against the edge with no gaps. Use a sharp knife or a flat-blade shovel to trim pieces to fit curves and odd angles.</p>
+        </div>
+
+        <div class="step-card">
+          <span class="step-number">2</span> <h4>Stagger the Seams Like Brickwork</h4>
+          <p>The second row should start with a half-piece so the seams are staggered, just like a brick wall. This prevents continuous seam lines that can dry out and pull apart. Staggering also locks the pieces together, reducing shrinkage gaps as the sod settles.</p>
+        </div>
+
+        <div class="step-card">
+          <span class="step-number">3</span> <h4>Tight Seams, No Gaps, No Overlap</h4>
+          <p>Press each piece firmly against its neighbors. The seams should be tight enough that you cannot see bare soil between rolls. <strong>Never overlap the edges</strong> &mdash; overlapping creates ridges that the mower scalps and that dry out faster than the rest of the lawn. If a piece overlaps the one next to it, trim the overlap with a knife rather than trying to stretch the sod.</p>
+        </div>
+
+        <div class="step-card">
+          <span class="step-number">4</span> <h4>Fit Around Obstacles</h4>
+          <p>For sprinkler heads, landscape lights, trees, and beds, lay the sod across the obstacle and cut an X or a custom shape with a knife, then press the sod down around it. Do not leave large gaps around obstacles &mdash; bare soil invites weeds and dries out the edges of the adjacent sod.</p>
+        </div>
+
+        <div class="step-card">
+          <span class="step-number">5</span> <h4>Roll the Entire Lawn</h4>
+          <p>After all the sod is laid, go over the entire area with a lawn roller (about one-third full of water). Rolling ensures the roots make good contact with the soil beneath. Air pockets between the sod and the soil are one of the leading causes of root failure &mdash; the roots cannot reach the soil to draw moisture, and the sod dries out from underneath.</p>
+        </div>
+
+        <div class="warning-box">
+          <strong>Critical:</strong> Do not walk on freshly laid sod more than necessary. Foot traffic before the roots anchor can shift the pieces, create air gaps, and compress the soil unevenly. Use planks to distribute your weight if you need to access the middle of the installation area.
+        </div>
+
+        <h2>Watering Schedule: The Critical First Four Weeks</h2>
+        <p>
+          Watering is the single most important factor in sod establishment. New sod has a very limited root system &mdash; it can only absorb moisture through the cut bottom and the small roots that are just beginning to grow. If the sod dries out even once during the first week, large sections can die before they ever root.
+        </p>
+        <p>
+          This schedule assumes South Louisiana weather (hot, humid, with occasional rain). Adjust based on actual conditions &mdash; if it rains, skip a watering; if a heat wave hits, water more often.
+        </p>
+
+        <div class="schedule-box">
+          <h4>Days 1 through 7 &mdash; Keep Sod Constantly Moist</h4>
+          <p><strong>Water 2 to 3 times daily.</strong> Morning, midday, and late afternoon. Each session should deliver about 1/4 to 1/2 inch of water. The goal is to keep the soil under the sod damp at all times. Lift a corner of a piece to check &mdash; the underside should feel wet, not just the top of the grass blades. If the sod feels warm or looks bluish-gray, it is drying out and needs water immediately.</p>
+        </div>
+
+        <div class="schedule-box">
+          <h4>Days 8 through 14 &mdash; Deep Soak Once Daily</h4>
+          <p><strong>Water 1 time daily, deep soak.</strong> Deliver about 1 inch of water in a single session. The deeper watering encourages roots to grow downward into the soil rather than staying shallow. By day 10 to 12, you should feel resistance when you gently tug on a corner of the sod &mdash; that is the roots grabbing the soil.</p>
+        </div>
+
+        <div class="schedule-box">
+          <h4>Days 15 through 21 &mdash; Water Every Other Day</h4>
+          <p><strong>Water every other day, about 3/4 inch per session.</strong> The roots are now reaching into the native soil and can start drawing moisture from deeper layers. Skip a day between waterings to encourage the roots to chase moisture deeper still.</p>
+        </div>
+
+        <div class="schedule-box">
+          <h4>Week 4 and Beyond &mdash; Normal Watering Schedule</h4>
+          <p><strong>Water 1 to 2 times per week</strong> with 1 to 1.5 inches per session, depending on weather. The lawn is now established and should be treated like mature grass. Follow the <a href="/blog-watering-guide">Louisiana watering guide</a> for long-term irrigation recommendations.</p>
+        </div>
+
+        <h2>First Mow</h2>
+        <p>
+          Mowing too early is one of the most common and damaging mistakes new sod owners make. <strong>Wait at least 14 days</strong> after installation before the first mow, and only mow if the sod has rooted firmly enough that it does not pull up when lifted by the corner. If the sod peels back easily, wait another three to five days.
+        </p>
+        <ul>
+          <li><strong>Mow at the highest setting</strong> on your mower. For St. Augustine, that means 3.5 to 4 inches. For Bermuda and Zoysia, 2.5 to 3 inches. Taller grass shades the soil, reduces water evaporation, and gives the roots more energy to establish.</li>
+          <li>Use a sharp blade. A dull blade tears the grass, leaving ragged edges that turn brown and stress the new lawn.</li>
+          <li>Never remove more than one-third of the grass blade height in a single mow. If the sod was delivered tall, mow it down gradually over several sessions.</li>
+          <li>Bag the clippings for the first one or two mows to avoid smothering the young grass. After that, leave the clippings to return nutrients to the soil.</li>
+        </ul>
+
+        <h2>First Fertilize</h2>
+        <p>
+          The starter fertilizer you applied before installation gives the sod enough phosphorus for initial root growth. But after 30 days, the sod needs a balanced feeding to support top growth and overall health.
+        </p>
+        <ul>
+          <li><strong>Wait a full 30 days</strong> after installation before applying any additional fertilizer.</li>
+          <li>Use a <strong>balanced fertilizer</strong> such as 15-15-15 or 16-4-8 at the bag rate (typically 6 to 8 pounds per 1,000 sq ft). The balanced nitrogen supports leaf growth, while phosphorus and potassium continue supporting roots and stress tolerance.</li>
+          <li>Water the fertilizer in immediately after application to move the nutrients to the root zone and prevent burn.</li>
+          <li>Follow the <a href="/blog-fertilizing-guide">Louisiana fertilizing schedule</a> for the rest of the growing season. In general, warm-season grasses in the River Parishes need fertilizer every six to eight weeks during the active growing months (April through September).</li>
+        </ul>
+
+        <div class="tip-box">
+          <strong>Signs your sod needs fertilizer after 30 days:</strong> The grass takes on a lighter green or yellow-green color, growth slows noticeably, or the lawn does not bounce back after mowing as quickly as it did in weeks two and three.
+        </div>
+
+        <h2>Common Mistakes and How to Avoid Them</h2>
+        <p>
+          Even with good intentions, homeowners make predictable mistakes during sod establishment. Here are the most common ones we see in South Louisiana:
+        </p>
+
+        <div class="warning-box">
+          <strong>Mistake 1: Letting sod dry out during week one.</strong> The most fatal error. Sod that dries out completely in the first week will not recover &mdash; it turns brown, shrinks, and dies. The seams pull apart, and you are left with dead strips between living sections. Prevention: water on schedule, check under a corner daily, and do not rely on rain alone.
+        </div>
+
+        <div class="warning-box">
+          <strong>Mistake 2: Walking and playing on new sod.</strong> Kids, pets, and foot traffic before roots anchor dislodge the sod from the soil. The roots that have just started growing are torn, and the sod has to start over. Keep everyone off the lawn for at least two weeks. Light foot traffic after the first mow is okay; full use can wait until week four or five.
+        </div>
+
+        <div class="warning-box">
+          <strong>Mistake 3: Mowing too early or too short.</strong> See the first mow section above. Mowing before the sod has rooted lifts and shifts the pieces. Mowing too short reduces the leaf area the grass needs to photosynthesize, weakening the whole lawn. Patience pays off.
+        </div>
+
+        <div class="warning-box">
+          <strong>Mistake 4: Under-fertilizing after establishment.</strong> Some homeowners assume that the starter fertilizer is enough for the whole season. It is not. Warm-season grasses in Louisiana grow vigorously for six to seven months and need regular feeding to stay thick, green, and healthy. Skipping fertilizer after the first 30 days leads to a thin, pale, weed-prone lawn. Follow a regular <a href="/blog-fertilizing-guide">fertilization schedule</a> for best results.
+        </div>
+
+        <div class="warning-box">
+          <strong>Mistake 5: Installing sod over a drainage problem.</strong> If water pools in the yard after a hard rain, laying sod on top will not fix it. The sod will rot in the wet spots, and the problem will reappear within months. Fix the drainage &mdash; regrade the area, install French drains, or add downspout extensions &mdash; before you spend money on sod. (<a href="/blog-shade-drainage-guide">Read our shade and drainage guide for Louisiana lawns.</a>)
+        </div>
+
+        <div class="cta-box">
+          <p><strong>Need sod installed or evaluated by professionals?</strong> We handle the full job &mdash; site prep, grading, sod installation, and follow-up care. Serving LaPlace, Hammond, Ponchatoula, and the entire River Parishes region.</p>
+          <p>
+            <a href="home.html#waitlist">Request a Free Quote</a> &middot;
+            <a href="tel:+19855551234">Call (985) 555-1234</a> &middot;
+            <a href="blog.html">Back to Blog Hub</a>
+          </p>
+        </div>
+
+        <div class="related">
+          <h2>Related Reading</h2>
+          <ul>
+            <li><a href="blog-grass-types.html">Best Grass Types for LaPlace, Louisiana</a> &mdash; Choosing between St. Augustine, Bermuda, Zoysia, and Centipede for your yard.</li>
+            <li><a href="blog-watering-guide.html">Lawn Watering Guide for South Louisiana</a> &mdash; Long-term irrigation strategies after the establishment period.</li>
+            <li><a href="blog-fertilizing-guide.html">Fertilizing Guide for Louisiana Lawns</a> &mdash; Complete year-round fertilization schedule for warm-season grasses.</li>
+          </ul>
+        </div>
+
+        <a class="backlink" href="blog.html">&larr; Back to the South Louisiana Blog Hub</a>
+      </article>
+    </main>
+
+    <footer class="blog-footer">
+      <p><strong>&copy; 2025 Xcellent1 Lawn Care</strong></p>
+      <p style="font-size: 0.9rem; opacity: 0.8">
+        Serving the River Parishes, Louisiana
+      </p>
+    </footer>
+  </body>
+</html>

--- a/web/static/blog-storm-recovery-guide.html
+++ b/web/static/blog-storm-recovery-guide.html
@@ -1,0 +1,565 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Storm Recovery & Cleanup for South Louisiana Lawns | Xcellent1 Lawn Care Blog</title>
+    <meta name="description" content="Complete storm recovery guide for South Louisiana lawns: safety, debris cleanup, flooding recovery, lawn assessment, recovery timeline, tree damage, and prevention tips for the River Parishes." />
+    <!-- Open Graph -->
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://xcellent1lawncare.com/blog-storm-recovery-guide" />
+    <meta property="og:title" content="Storm Recovery & Cleanup for South Louisiana Lawns" />
+    <meta property="og:description" content="Complete storm recovery guide: safety, debris cleanup, flooding recovery, lawn assessment, recovery timeline, tree damage, and prevention for the River Parishes." />
+    <meta property="og:image" content="https://xcellent1lawncare.com/images/bushhog.webp" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="article:published_time" content="2025-12-20" />
+    <meta property="article:modified_time" content="2026-06-10" />
+    <meta property="og:site_name" content="Xcellent1 Lawn Care" />
+    <meta property="og:locale" content="en_US" />
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Storm Recovery & Cleanup for South Louisiana Lawns" />
+    <meta name="twitter:description" content="Complete storm recovery guide: safety, debris cleanup, flooding recovery, lawn assessment, recovery timeline, tree damage, and prevention for the River Parishes." />
+    <meta name="twitter:image" content="https://xcellent1lawncare.com/images/bushhog.webp" />
+    <link rel="canonical" href="https://xcellent1lawncare.com/blog-storm-recovery-guide" />
+    <link rel="icon" type="image/png" sizes="32x32" href="images/favicon.ico" />
+    <link rel="stylesheet" href="styles.clean.css" />
+    <meta name="theme-color" content="#3b832a" />
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "Storm Recovery & Cleanup for South Louisiana Lawns",
+        "description": "Complete storm recovery guide for South Louisiana lawns: safety, debris cleanup, flooding recovery, lawn assessment, recovery timeline, tree damage, and prevention tips for the River Parishes.",
+        "author": { "@type": "Organization", "name": "Xcellent1 Lawn Care" },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Xcellent1 Lawn Care"
+        },
+        "datePublished": "2025-12-20",
+        "dateModified": "2026-06-10",
+        "mainEntityOfPage": {
+          "@type": "WebPage",
+          "@id": "https://xcellent1lawncare.com/blog-storm-recovery-guide"
+        }
+      }
+    </script>
+    <style>
+      .blog-hero {
+        background:
+          linear-gradient(
+            135deg,
+            rgba(59, 131, 42, 0.88),
+            rgba(19, 63, 28, 0.94)
+          ),
+          url("images/bushhog.webp") center/cover;
+        padding: 5rem 1rem;
+        text-align: center;
+        color: #fff;
+      }
+      .blog-hero h1 {
+        font-size: clamp(2rem, 4vw, 3.2rem);
+        margin-bottom: 0.75rem;
+        font-weight: 800;
+        text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+      }
+      .blog-hero .meta {
+        font-size: 0.95rem;
+        opacity: 0.95;
+        display: flex;
+        justify-content: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+      .reading-time {
+        background: rgba(255, 255, 255, 0.2);
+        padding: 0.25rem 0.75rem;
+        border-radius: 20px;
+        font-size: 0.85rem;
+      }
+      .blog-container {
+        max-width: 860px;
+        margin: -3rem auto 0;
+        padding: 0 1rem 2rem;
+        position: relative;
+        z-index: 10;
+      }
+      .blog-content {
+        background: #fff;
+        border-radius: 16px;
+        padding: 2.25rem;
+        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
+      }
+      .blog-content > p:first-of-type {
+        font-size: 1.15rem;
+        color: #4b5563;
+        line-height: 1.8;
+      }
+      .blog-content h2 {
+        color: #166534;
+        margin: 2.5rem 0 1rem;
+        font-size: 1.5rem;
+        position: relative;
+        padding-bottom: 0.5rem;
+      }
+      .blog-content h2::after {
+        content: "";
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 60px;
+        height: 3px;
+        background: linear-gradient(90deg, #22c55e, #3b832a);
+        border-radius: 2px;
+      }
+      .blog-content h3 {
+        color: #15803d;
+        margin: 1.75rem 0 0.75rem;
+        font-size: 1.2rem;
+      }
+      .blog-content p, .blog-content li {
+        line-height: 1.8;
+        color: #374151;
+        font-size: 1.02rem;
+      }
+      .blog-content ul, .blog-content ol {
+        margin: 0.75rem 0 1.5rem;
+        padding-left: 1.25rem;
+      }
+      .blog-content ol li {
+        margin-bottom: 0.5rem;
+      }
+      .safety-box {
+        background: linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%);
+        border-left: 4px solid #dc2626;
+        border-radius: 12px;
+        padding: 1.5rem;
+        margin: 1.5rem 0;
+      }
+      .safety-box h3 {
+        color: #991b1b;
+        margin: 0 0 0.75rem;
+        font-size: 1.15rem;
+      }
+      .safety-box p, .safety-box li {
+        color: #7f1d1d;
+      }
+      .tip-box {
+        background: linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%);
+        border-left: 4px solid #22c55e;
+        border-radius: 12px;
+        padding: 1.5rem;
+        margin: 1.5rem 0;
+      }
+      .tip-box h3 {
+        color: #166534;
+        margin: 0 0 0.75rem;
+        font-size: 1.15rem;
+      }
+      .tip-box p, .tip-box li {
+        color: #14532d;
+      }
+      .warning-box {
+        background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%);
+        border-left: 4px solid #f59e0b;
+        border-radius: 12px;
+        padding: 1.5rem;
+        margin: 1.5rem 0;
+      }
+      .warning-box h3 {
+        color: #92400e;
+        margin: 0 0 0.75rem;
+        font-size: 1.15rem;
+      }
+      .warning-box p, .warning-box li {
+        color: #78350f;
+      }
+      .timeline-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 1rem;
+        margin: 1.5rem 0;
+      }
+      .timeline-card {
+        background: #f9fafb;
+        border: 1px solid #e5e7eb;
+        border-radius: 12px;
+        padding: 1.25rem;
+        text-align: center;
+      }
+      .timeline-card h4 {
+        color: #166534;
+        margin: 0 0 0.5rem;
+        font-size: 1.1rem;
+      }
+      .timeline-card .week-label {
+        display: inline-block;
+        background: linear-gradient(90deg, #22c55e, #3b832a);
+        color: #fff;
+        font-weight: 700;
+        font-size: 0.85rem;
+        padding: 0.2rem 0.75rem;
+        border-radius: 20px;
+        margin-bottom: 0.75rem;
+      }
+      .timeline-card p {
+        font-size: 0.92rem;
+        color: #4b5563;
+        margin: 0;
+      }
+      .related {
+        border-top: 1px solid #e5e7eb;
+        margin-top: 2rem;
+        padding-top: 1.5rem;
+      }
+      .related a {
+        color: #166534;
+        text-decoration: none;
+        font-weight: 700;
+      }
+      .related a:hover {
+        text-decoration: underline;
+      }
+      .cta-box {
+        margin-top: 2rem;
+        padding: 1.2rem 1.4rem;
+        border-radius: 14px;
+        background: #f0fdf4;
+        border: 1px solid #bbf7d0;
+      }
+      .cta-box a { color: #14532d; font-weight: 800; }
+      .cta-box a:hover { color: #166534; text-decoration: underline; }
+      .backlink {
+        display: inline-block;
+        margin-top: 1.5rem;
+        color: #166534;
+        font-weight: 700;
+      }
+      .backlink:hover {
+        text-decoration: underline;
+      }
+      .blog-footer {
+        background: rgba(1, 39, 20, 0.98);
+        color: #fff;
+        text-align: center;
+        padding: 2.5rem 1rem;
+        margin-top: 3rem;
+      }
+      @media (max-width: 640px) {
+        .blog-content { padding: 1.35rem; }
+        .blog-hero { padding: 4rem 1rem 2.5rem; }
+        .timeline-grid { grid-template-columns: 1fr; }
+      }
+    </style>
+  </head>
+  <body>
+    <nav class="navbar">
+      <div class="navbar-brand">
+        <img
+          src="images/xcellent1-logo-transparent.png"
+          alt="Xcellent1 logo"
+          class="navbar-logo"
+        />
+        <div class="navbar-title">
+          <span class="navbar-name">XCELLENT1</span>
+          <span class="navbar-tagline">LAWN CARE</span>
+        </div>
+      </div>
+      <div class="navbar-links">
+        <a href="home.html" class="navbar-link">Home</a>
+        <a href="shop.html" class="navbar-link">Shop</a>
+        <a href="careers.html" class="navbar-link">Careers</a>
+        <a href="login.html" class="navbar-login">Login</a>
+      </div>
+    </nav>
+
+    <header class="blog-hero">
+      <div class="blog-container">
+        <h1>Storm Recovery & Cleanup for South Louisiana Lawns</h1>
+        <div class="meta">
+          <span>📅 December 20, 2025</span>
+          <span class="reading-time">📖 12 min read</span>
+          <span>Storm recovery · River Parishes</span>
+        </div>
+      </div>
+    </header>
+
+    <main class="blog-container">
+      <article class="blog-content">
+        <p>Storms do not just knock down branches. They change drainage, compact soil, spread fungus, and leave lawns needing a complete reset. South Louisiana properties in the River Parishes face unique challenges after severe weather — from saltwater intrusion during storm surge to the heavy clay soils that stay waterlogged for weeks. A smart recovery plan, not just a quick cleanup, is what separates a lawn that bounces back from one that needs full replacement.</p>
+
+        <p>This guide walks you through every stage of storm recovery: staying safe during cleanup, clearing debris without damaging your turf, managing flood damage, assessing what survived, and following a week-by-week recovery timeline. Whether you are dealing with a hurricane, severe thunderstorm, or the remnants of a tropical system, these steps apply to Louisiana lawns all year.</p>
+
+        <div class="safety-box">
+          <h3>⚠️ Before You Step Outside: Safety First</h3>
+          <p>Your lawn can wait. Safety cannot. Louisiana storms often leave hazards that are not obvious at first glance. Follow these rules before you begin any cleanup work:</p>
+          <ul>
+            <li><strong>Downed power lines.</strong> Assume every downed line is live. Stay at least 30 feet away and report them to Entergy or your local utility immediately. Never touch a line with any tool, including plastic or wooden handles — moisture conducts electricity.</li>
+            <li><strong>Gas leaks.</strong> If you smell natural gas or hear a hissing sound near your yard, evacuate the area and call Atmos Energy or your gas provider from outside. Do not operate any equipment (generators, mowers, trimmers) near a suspected leak.</li>
+            <li><strong>Hidden debris.</strong> Floodwater hides sharp metal, broken glass, nails, and displaced wildlife (snakes and alligators are common after flooding in the River Parishes). Wear thick work boots, long pants, and heavy gloves.</li>
+            <li><strong>Structural instability.</strong> Leaning trees, dangling limbs, loose fencing, and damaged decks can collapse without warning. Stay clear until a professional assesses them.</li>
+            <li><strong>Generator safety.</strong> If you are running a generator during power loss, keep it outdoors and at least 20 feet from the house. Carbon monoxide poisoning is the leading cause of storm-related deaths after hurricanes.</li>
+          </ul>
+        </div>
+
+        <h2>Debris Cleanup Without Damaging Your Lawn</h2>
+
+        <p>Once the immediate safety threats are handled, debris removal is the top priority. Branches, leaves, and storm debris left on the lawn for more than a few days can smother the grass, trap moisture against the blades, and create the perfect environment for fungal diseases. In the River Parishes' humid climate, that window is even shorter.</p>
+
+        <h3>When to remove debris</h3>
+        <p>Remove debris as soon as it is safe to go outside and the ground is dry enough to walk on without sinking more than half an inch. Walking on saturated, debris-covered turf causes compaction that takes months to undo. If the ground is still soggy, lay down plywood sheets or wide planks to distribute your weight while you work.</p>
+
+        <h3>How to remove debris without tearing up turf</h3>
+        <ul>
+          <li><strong>Hand-pick large branches.</strong> Drag them gently — never yank. Pulling a branch across wet turf tears runners and pulls out grass crowns. Lift rather than drag whenever possible.</li>
+          <li><strong>Use a leaf rake for leaves and twigs.</strong> A gentle leaf rake (not a stiff thatching rake) lifts surface debris without pulling up grass roots. Rake in one direction to minimize stress on the turf.</li>
+          <li><strong>Blower for fine debris.</strong> A backpack or handheld blower works well for leaves, pine straw, and small twigs on dry or slightly damp grass. Avoid using a blower on muddy lawns — it will just spray mud across everything.</li>
+          <li><strong>Avoid mowing over debris.</strong> Running a mower over scattered sticks and branches throws projectiles, dulls your blade, and can shred the turf underneath. Clear everything first, then mow.</li>
+          <li><strong>Check for and remove silt deposits.</strong> Floodwater often leaves a thin layer of silt over lawns. A light layer (less than a quarter inch) can be left alone — it adds organic matter. Thicker deposits should be gently hosed off or raked away. Leaving heavy silt smothers the grass crowns.</li>
+        </ul>
+
+        <div class="tip-box">
+          <h3>🟢 Disposal Options in the River Parishes</h3>
+          <p>St. John the Baptist, St. Charles, and St. James parishes all have storm debris collection protocols after declared emergencies. Here is what to know:</p>
+          <ul>
+            <li><strong>Curbside pickup:</strong> During declared events, parishes typically waive normal pickup limits. Separate vegetative debris (branches, leaves) from construction debris and appliances. Stack vegetation parallel to the road, cut end facing the street.</li>
+            <li><strong>Self-haul drop-off:</strong> The St. John the Baptist Parish landfill on Water Plant Road accepts vegetative debris. St. Charles Parish operates a debris drop-off site at the East Bank Bridge Park during active storm recovery. Call ahead — hours often extend after storms.</li>
+            <li><strong>Burning:</strong> Open burning of storm debris is regulated by the Louisiana Department of Environmental Quality and local fire departments. Most parishes allow it only during designated periods with a permit. Check with your parish fire marshal before lighting any burn pile.</li>
+            <li><strong>Xcellent1 service:</strong> We offer full debris haul-off as part of our storm recovery package. We load, haul, and properly dispose of vegetative debris so you do not have to coordinate with parish pickup schedules. <a href="home.html#waitlist">Request service here</a>.</li>
+          </ul>
+        </div>
+
+        <h2>Flooding Recovery in South Louisiana</h2>
+
+        <p>Flooding is the most damaging storm event for Louisiana lawns. Standing water suffocates grass roots, introduces contaminants, and sets the stage for disease. In the River Parishes, where the Mississippi River and Lake Pontchartrain influence drainage, flood recovery is a recurring skill every lawn owner needs.</p>
+
+        <h3>Standing water damage</h3>
+        <p>Most warm-season grasses used in Louisiana (St. Augustine, Bermuda, Zoysia, Centipede) can survive 3 to 5 days of standing water during the growing season. Beyond that, the roots begin to die from lack of oxygen. The grass may initially look fine — green above ground — while the roots are already failing below. If standing water lasted more than 5 days in a given area, expect some or all of that grass to die over the next 2 to 3 weeks.</p>
+
+        <ul>
+          <li>Do not walk on or mow waterlogged turf. The soil structure collapses under pressure, creating deep ruts and compaction.</li>
+          <li>Do not add fertilizer immediately. Roots cannot absorb nutrients when waterlogged, and the nitrogen will just wash into local waterways.</li>
+          <li>Once water recedes, monitor the lawn closely for the next two weeks. Yellowing or thinning grass indicates root damage.</li>
+          <li>For areas with poor natural drainage, consider French drains or catch basins before the next rainy season. Our <a href="blog-shade-drainage-guide.html">drainage guide</a> covers solutions for River Parishes properties.</li>
+        </ul>
+
+        <div class="warning-box">
+          <h3>🌊 Saltwater Intrusion: A Coastal Louisiana Problem</h3>
+          <p>If your property is near Lake Pontchartrain, the Mississippi River, or any tidal waterway, storm surge can push saltwater onto your lawn. Salt damage is different from freshwater flood damage and often more deadly to grass:</p>
+          <ul>
+            <li><strong>Symptoms:</strong> Grass appears burned or scorched along the tips within 24 to 48 hours. Leaf blades turn brown from the tip downward. The damage spreads over the next week as salt moves through the root zone.</li>
+            <li><strong>Immediate action:</strong> As soon as floodwater recedes, flush the lawn with fresh water. Apply 1 to 2 inches of fresh water per day for 3 to 4 days to push salts below the root zone. This is the single most important step for saltwater recovery.</li>
+            <li><strong>Gypsum application:</strong> After flushing, apply gypsum (calcium sulfate) at a rate of 40 to 50 pounds per 1,000 square feet. Gypsum displaces sodium ions and improves soil structure without raising pH.</li>
+            <li><strong>Patience:</strong> Severely salt-damaged St. Augustine often dies outright. Bermuda and Zoysia have better salt tolerance and may recover over 4 to 8 weeks with proper flushing and care.</li>
+          </ul>
+        </div>
+
+        <h3>Silt and sediment deposits</h3>
+        <p>Floodwater carries sediment, and when it recedes, that sediment settles on your lawn. A thin layer (less than half an inch) can be beneficial — it contains organic matter and nutrients. Thicker layers smother the grass. Remove heavy silt deposits by gently hosing the area during dry weather, using a fan spray to wash sediment off the blades. For large areas, a light rake after the silt dries helps break up the crust so the grass can push through.</p>
+
+        <h3>Fungal disease prevention after flooding</h3>
+        <p>Warm temperatures plus standing water equals a fungal explosion. Large patch, brown patch, and gray leaf spot are extremely common in Louisiana lawns after heavy rain and flooding. Follow these prevention steps:</p>
+        <ul>
+          <li><strong>Improve airflow.</strong> Trim back overgrown shrubs and low-hanging tree limbs so sunlight and breeze reach the lawn.</li>
+          <li><strong>Avoid evening watering.</strong> After a flood, the lawn already has too much moisture. Do not irrigate for at least a week unless you are flushing saltwater.</li>
+          <li><strong>Preventive fungicide.</strong> Apply a broad-spectrum fungicide (azoxystrobin or propiconazole) 3 to 5 days after the water recedes, before symptoms appear. Waiting until you see disease means you are already behind.</li>
+          <li><strong>Mow high.</strong> Keep grass at the upper end of its recommended height range. Taller grass develops deeper roots and resists disease better than scalped turf.</li>
+          <li><strong>Clean your mower.</strong> Mower decks spread fungal spores from infected areas to healthy ones. Spray the underside of your deck with a hose or disinfectant between uses.</li>
+        </ul>
+
+        <h2>Lawn Assessment: Can It Be Saved or Does It Need Replacement?</h2>
+
+        <p>After the debris is cleared and floodwater has receded, it is time to assess what is alive and what is not. Storm-damaged lawns often look worse than they actually are. Many grasses can recover from surprisingly severe stress if the roots survived.</p>
+
+        <h3>Green vs. dead: what to look for</h3>
+        <p>Healthy grass after a storm still has firm green tissue at the base of the leaf blades, near the soil line. Dead grass pulls away easily from the crown. Look for these signs:</p>
+        <ul>
+          <li><strong>Green at the base = alive.</strong> Even if the leaf tips are brown or yellow, grass with green tissue near the soil line will grow back with proper care.</li>
+          <li><strong>Brown all the way down = dead.</strong> If the entire blade, including the crown area, is brown and brittle, that grass is gone. Dead patches will not green up again.</li>
+          <li><strong>Mushy or rotten smell = root rot.</strong> If the soil smells sour and grass pulls up in mats with no root structure, root rot has set in. That area needs re-sodding or overseeding.</li>
+        </ul>
+
+        <h3>The tug test</h3>
+        <p>The most reliable way to check grass survival is the tug test. Take a handful of grass near the base and gently pull upward:</p>
+        <ul>
+          <li><strong>Firm resistance:</strong> The roots are alive and anchored. The grass will recover.</li>
+          <li><strong>Pulls up easily with some roots attached:</strong> The roots are stressed but may recover with aeration and reduced stress.</li>
+          <li><strong>Comes up with no roots — just a mat of rotting stolons:</strong> The grass is dead. Plan for sod or seed.</li>
+        </ul>
+
+        <p>Perform the tug test in multiple spots across your lawn, especially in low areas that held standing water the longest. Mark the dead patches with landscape flags or brightly colored stakes so you can track them over the next few weeks.</p>
+
+        <div class="tip-box">
+          <h3>🟢 When to call a professional for assessment</h3>
+          <p>If more than 30 percent of your lawn appears damaged, or if you are unsure whether the grass is alive or dead, a professional lawn assessment is worth the investment. Xcellent1 Lawn Care offers free storm damage assessments for River Parishes properties. We test soil compaction, root depth, and fungal pressure, then give you a clear recovery plan. <a href="home.html#waitlist">Schedule your free assessment</a>.</p>
+        </div>
+
+        <h2>Recovery Timeline: Weeks 1 Through 4</h2>
+
+        <p>Storm recovery is measured in weeks, not days. Pushing too hard, too fast is the most common mistake. The grass needs rest, then a gradual return to normal care. Here is a week-by-week plan tailored to South Louisiana lawns.</p>
+
+        <div class="timeline-grid">
+          <div class="timeline-card">
+            <div class="week-label">Week 1</div>
+            <h4>Cleanup & Aeration</h4>
+            <p>Clear debris. Aerate compacted areas. Resist the urge to fertilize. Let the lawn breathe.</p>
+          </div>
+          <div class="timeline-card">
+            <div class="week-label">Week 2</div>
+            <h4>Fungicide & Light Feed</h4>
+            <p>Apply preventive fungicide. Light fertilization with low-nitrogen formula. Monitor for disease.</p>
+          </div>
+          <div class="timeline-card">
+            <div class="week-label">Week 3</div>
+            <h4>Overseed or Sod</h4>
+            <p>Prepare bare spots. Overseed thin areas. Install sod where grass is completely dead.</p>
+          </div>
+          <div class="timeline-card">
+            <div class="week-label">Week 4+</div>
+            <h4>Return to Routine</h4>
+            <p>Resume normal mowing height. Full fertilizing schedule. Monitor new growth.</p>
+          </div>
+        </div>
+
+        <h3>Week 1: Cleanup and aeration</h3>
+        <p>Your first week is all about removing stress and restoring airflow to the root zone:</p>
+        <ul>
+          <li><strong>Finish debris removal</strong> if the initial cleanup was partial. Every day debris sits on the lawn, the grass underneath weakens.</li>
+          <li><strong>Core aeration</strong> if the soil is compacted. Stormwater compacts soil heavily, especially in lawns with clay-heavy River Parishes soil. Rent a core aerator or hire a service to pull plugs. Aeration relieves compaction, improves oxygen exchange, and lets roots breathe.</li>
+          <li><strong>Do not mow yet</strong> unless the grass is obviously growing. Let the lawn rest for at least 5 to 7 days after the storm before the first mow.</li>
+          <li><strong>Do not fertilize.</strong> Stressed roots cannot absorb nutrients. Applying fertilizer to a stressed lawn feeds the weeds and fungus instead of the grass.</li>
+          <li><strong>Do not irrigate</strong> unless you are flushing saltwater. The soil is already saturated.</li>
+        </ul>
+
+        <h3>Week 2: Fungicide and light fertilizing</h3>
+        <p>By week two, the grass should be showing signs of life — new green growth at the base, or at least stable color:</p>
+        <ul>
+          <li><strong>Preventive fungicide application.</strong> Even if you see no symptoms, apply a broad-spectrum fungicide. Louisiana humidity after a storm is a guaranteed fungal bloom without it. Follow label rates carefully.</li>
+          <li><strong>Light fertilization</strong> with a low-nitrogen, slow-release formula (look for a 15-0-15 or similar blend with low or no quick-release nitrogen). Apply at half the normal rate. This provides a gentle nutrient boost without forcing rapid top growth that the roots cannot support.</li>
+          <li><strong>First mow of the season</strong> once the grass is dry and firm. Set the mower deck one notch higher than your normal summer height. Use a sharp blade. Bag the clippings to remove any debris and reduce disease pressure.</li>
+          <li><strong>Monitor for drainage problems.</strong> If certain areas stay soggy longer than others, mark them for improvement later. Consider French drains, dry wells, or regrading in those spots. Our <a href="blog-shade-drainage-guide.html">shade and drainage guide</a> covers drainage solutions in detail.</li>
+        </ul>
+
+        <h3>Weeks 3-4: Repairs — overseeding and sodding bare spots</h3>
+        <p>By now you should have a clear picture of what survived and what did not. Bare spots and dead patches need active repair:</p>
+        <ul>
+          <li><strong>Prepare the soil.</strong> Rake dead grass out of bare spots. Loosen the top inch of soil. Add a thin layer of compost or topsoil if the area is low and tends to hold water.</li>
+          <li><strong>Overseed thin areas.</strong> For Bermuda and Zoysia lawns, broadcast seed at the recommended rate and cover lightly with peat moss or straw to hold moisture. Water lightly once or twice daily until germination (7 to 14 days).</li>
+          <li><strong>Sod for large dead zones.</strong> St. Augustine lawns cannot be overseeded effectively — they must be re-sodded or plugged. Cut out the dead sections with a square shovel, prepare the soil, and install fresh sod. Keep new sod consistently moist for the first 2 weeks.</li>
+          <li><strong>Water correctly.</strong> New seed or sod needs consistent moisture. Water daily in the morning, avoiding evening watering that invites fungus. After the first 2 weeks, taper back to a normal schedule.</li>
+          <li><strong>Wait on heavy fertilizer.</strong> Hold off on high-nitrogen fertilizer until the new grass is established and actively growing (about 4 to 6 weeks after installation). Premature feeding burns tender new roots.</li>
+        </ul>
+
+        <p>If you are unsure which approach is right for your lawn, read our <a href="blog-watering-guide.html">watering guide</a> for details on irrigation schedules after repair work, and our <a href="blog-sod-installation-guide.html">sod installation guide</a> for step-by-step instructions on laying fresh St. Augustine sod.</p>
+
+        <h2>Tree Damage: When to Act and When to Call an Arborist</h2>
+
+        <p>Hurricanes and severe thunderstorms in Louisiana frequently damage trees. Broken limbs, split trunks, and leaning trees are dangerous and also affect your lawn's recovery — damaged trees drop debris for months, shade out recovering grass, and compete for water and nutrients.</p>
+
+        <h3>Broken limbs and storm-damaged branches</h3>
+        <p>Small broken branches (under 2 inches in diameter) can be pruned by a homeowner with proper tools. Make clean cuts at the branch collar — never leave a stub, and never make a flush cut against the trunk. For branches larger than 2 inches, or any branch that is hanging but still attached, call a professional arborist. Hanging limbs ("widow-makers") can fall days or weeks after the storm.</p>
+
+        <ul>
+          <li><strong>Prune promptly.</strong> Torn bark and split wood are entry points for pests and disease. Clean up ragged breaks with a sharp pruning saw.</li>
+          <li><strong>Do not top trees.</strong> Cutting the main leader or topping a tree creates weak regrowth that is more likely to fail in the next storm. Proper pruning removes only damaged wood.</li>
+          <li><strong>Dispose of diseased wood away from healthy trees.</strong> If you suspect oak wilt, laurel wilt, or other vascular diseases, do not chip the wood or leave it near healthy trees. Bag it for disposal.</li>
+        </ul>
+
+        <h3>Leaning trees</h3>
+        <p>A tree that is leaning after a storm is a serious safety hazard. Uprooted roots may have broken underground, even if the soil surface looks intact:</p>
+        <ul>
+          <li><strong>Leaning with exposed roots:</strong> The tree has partially uprooted. It is a fall risk. Call an arborist immediately. Do not attempt to straighten it yourself — this almost always kills the tree and can cause it to fall later.</li>
+          <li><strong>Leaning with no visible root disturbance:</strong> The tree may have shifted in saturated soil. Some trees self-correct as the soil dries. Wait 2 to 3 weeks and monitor. If the lean worsens or new cracks appear at the base, call an arborist.</li>
+          <li><strong>Young or recently planted trees:</strong> If a young tree (trunk under 4 inches) is leaning but the root ball is intact, you can straighten it and stake it for one growing season. Drive two stakes on opposite sides and tie with broad straps (never wire or rope that cuts bark). Remove the stakes after 12 months.</li>
+        </ul>
+
+        <div class="warning-box">
+          <h3>🌳 When to Call a Certified Arborist</h3>
+          <p>Professional help is needed when:</p>
+          <ul>
+            <li>A tree is leaning more than 15 degrees from vertical.</li>
+            <li>Bark is split or peeled away from the trunk.</li>
+            <li>A major limb (over 4 inches in diameter) is cracked or hanging.</li>
+            <li>The tree is near a structure, driveway, or power line.</li>
+            <li>You are unsure whether a tree is stable — better to pay for a visit than gamble with a fall.</li>
+          </ul>
+          <p>Xcellent1 Lawn Care partners with certified arborists in the River Parishes. We can recommend a qualified professional as part of your storm recovery assessment.</p>
+        </div>
+
+        <h2>Prevention: Preparing for Next Hurricane Season</h2>
+
+        <p>The best time to prepare for storm damage is before hurricane season starts. Every step you take in the calm months reduces the work and stress after a storm hits. Here is a prevention checklist for South Louisiana lawns.</p>
+
+        <h3>Improve drainage before hurricane season</h3>
+        <p>Most storm damage to lawns is water damage. Improving drainage gives your grass a fighting chance when the next tropical system rolls through:</p>
+        <ul>
+          <li><strong>Clean gutters and downspouts.</strong> Clogged gutters dump thousands of gallons of water right next to your foundation and into your lawn. Clean them before rainy season and consider gutter guards if you have overhanging trees.</li>
+          <li><strong>Extend downspout outlets.</strong> Make sure downspouts discharge at least 5 feet from the house and away from the lawn, ideally into a drainage ditch, rain garden, or dry well.</li>
+          <li><strong>Install French drains or curtain drains.</strong> If your lawn has persistent low spots, a French drain channeling water to the street or a drainage ditch is worth the investment. These are best installed during dry weather, well before hurricane season.</li>
+          <li><strong>Grade the lawn.</strong> The ground should slope away from your house at a rate of at least 1 inch per 10 feet. If water pools around your foundation, regrading should be a priority.</li>
+          <li><strong>Consider a rain garden.</strong> In areas with poor drainage, a rain garden planted with native Louisiana species (blue flag iris, swamp sunflower, Gulf Coast penstemon) absorbs runoff and reduces flooding pressure on your lawn.</li>
+        </ul>
+
+        <p>For a deeper dive into drainage strategies, see our <a href="blog-shade-drainage-guide.html">shade and drainage guide</a>, which covers grading, French drains, and soil amendments for River Parishes properties.</p>
+
+        <h3>Prune weak limbs before storm season</h3>
+        <p>Preventive pruning is the single most effective way to reduce storm damage from trees:</p>
+        <ul>
+          <li><strong>Identify problem limbs.</strong> Look for dead wood, V-shaped crotches (which are weaker than U-shaped ones), branches that rub against each other, and limbs with heavy ends that overhang your house or driveway.</li>
+          <li><strong>Prune during dormancy.</strong> Late winter (January through February) is the best time for major pruning in Louisiana. Trees are dormant, which means less stress, and the bare canopy makes structural problems easy to see.</li>
+          <li><strong>Thin the canopy.</strong> Reducing the density of the crown by 15 to 20 percent lets wind pass through instead of pushing the tree over. Never remove more than 25 percent of live canopy in a single year.</li>
+          <li><strong>Remove co-dominant leaders.</strong> Trees with two main trunks (co-dominant stems) are much more likely to split in storms. If caught early, one leader can be removed. Large co-dominant trees may need cabling or should be removed by a professional.</li>
+          <li><strong>Hire a certified arborist for work near structures.</strong> Any limb that could hit a house, car, or power line if it falls is worth the cost of professional pruning.</li>
+        </ul>
+
+        <h3>Have a plan before the storm hits</h3>
+        <p>When a hurricane watch is issued, you should not be figuring out your lawn plan. Have these steps ready:</p>
+        <ul>
+          <li><strong>Mow short before the storm.</strong> Cut the grass to the lower end of its recommended height range (but not scalped). Shorter grass is less likely to trap debris and mat down under wind and rain. Tall grass after a storm is a breeding ground for fungus.</li>
+          <li><strong>Bring in or secure yard items.</strong> Patio furniture, grills, planters, yard decorations, and potted plants become projectiles in hurricane-force winds. Store them in a garage or shed before the storm.</li>
+          <li><strong>Know your parish debris pickup schedule.</strong> St. John, St. Charles, and St. James parishes all publish storm debris collection plans online. Bookmark the page and know the rules (vegetative separated from construction, pile orientation, etc.).</li>
+          <li><strong>Take photos before the storm.</strong> Photograph your lawn, trees, and property from multiple angles. Clear insurance documentation of pre-storm conditions speeds up claims if you have damage.</li>
+          <li><strong>Have a contact ready.</strong> Save our number. Xcellent1 Lawn Care provides priority storm recovery services to existing customers and offers free estimates for new clients. <a href="home.html#waitlist">Save our contact page</a> ahead of the season.</li>
+        </ul>
+
+        <div class="tip-box">
+          <h3>🟢 Seasonal Lawn Care Through the Year</h3>
+          <p>Storm recovery is one piece of the larger puzzle. A healthy lawn going into hurricane season recovers much faster than one already stressed by drought, pests, or poor mowing practices. Check out our <a href="blog-seasonal-tips.html">seasonal lawn care tips</a> for month-by-month maintenance advice tailored to the River Parishes climate. And for ongoing watering strategies to keep your lawn strong even during dry spells, read our <a href="blog-watering-guide.html">complete watering guide</a>.</p>
+        </div>
+
+        <h2>How to Manage Fungus and Pests After a Storm</h2>
+
+        <p>Storm-damaged lawns are vulnerable to pests and diseases. Chinch bugs, armyworms, and sod webworms all take advantage of stressed turf. Fungal diseases like large patch and brown patch are almost guaranteed after prolonged wet conditions. Combine storm recovery with vigilant pest management by reading our <a href="blog-pest-disease-guide.html">pest and disease guide</a>. Early identification — before the infestation spreads — saves you from re-sodding entire sections of lawn.</p>
+
+        <div class="cta-box">
+          <p><strong>Need storm cleanup, debris haul-off, damaged tree removal, or full lawn recovery services?</strong> Xcellent1 Lawn Care serves the entire River Parishes region — LaPlace, Reserve, Garyville, Luling, Destrehan, Hahnville, and all surrounding communities. We offer free estimates for storm recovery work and can dispatch a crew to assess and start recovery within 48 hours.</p>
+          <p>
+            <a href="home.html#waitlist">Schedule Free Assessment</a> ·
+            <a href="careers.html">Join Our Storm Recovery Team</a> ·
+            <a href="home.html">Return to Homepage</a>
+          </p>
+        </div>
+
+        <div class="related">
+          <h2>Related reading</h2>
+          <ul>
+            <li><a href="blog-seasonal-tips.html">Seasonal Lawn Care Tips for the River Parishes</a></li>
+            <li><a href="blog-shade-drainage-guide.html">Shade and Drainage Guide for South Louisiana Lawns</a></li>
+            <li><a href="blog-watering-guide.html">Complete Lawn Watering Guide</a></li>
+          </ul>
+        </div>
+
+        <a class="backlink" href="home.html#blog">&larr; Back to the South Louisiana Lawn Care Blog</a>
+      </article>
+    </main>
+
+    <footer class="blog-footer">
+      <p><strong>&copy; 2025 Xcellent1 Lawn Care</strong></p>
+      <p style="font-size: 0.9rem; opacity: 0.8">
+        Serving the River Parishes, Louisiana
+      </p>
+    </footer>
+  </body>
+</html>

--- a/web/static/blog-watering-guide.html
+++ b/web/static/blog-watering-guide.html
@@ -470,6 +470,23 @@
           </p>
           <a href="home.html#waitlist" class="btn">Get a Free Quote →</a>
         </div>
+    <div class="related-posts">
+      <h3 style="color:#1f2937; margin-bottom: 1rem; font-size: 1.25rem;">📚 Related Guides</h3>
+      <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem;">
+        <a href="blog-grass-types.html" style="display: block; padding: 1rem; background: #f9fafb; border-radius: 10px; text-decoration: none; color: #374151; border: 1px solid #e5e7eb;">
+          <strong style="color: #10b981;">🌿</strong>
+          <span style="font-size: 0.9rem;">Best Grass Types for LaPlace</span>
+        </a>
+        <a href="blog-fertilizing-guide.html" style="display: block; padding: 1rem; background: #f9fafb; border-radius: 10px; text-decoration: none; color: #374151; border: 1px solid #e5e7eb;">
+          <strong style="color: #10b981;">🧪</strong>
+          <span style="font-size: 0.9rem;">Fertilize a Louisiana Lawn</span>
+        </a>
+        <a href="blog-mowing-height-guide.html" style="display: block; padding: 1rem; background: #f9fafb; border-radius: 10px; text-decoration: none; color: #374151; border: 1px solid #e5e7eb;">
+          <strong style="color: #10b981;">✂️</strong>
+          <span style="font-size: 0.9rem;">Mowing Height Guide</span>
+        </a>
+      </div>
+    </div>
 
         <a href="home.html#blog" class="back-link">← Back to All Articles</a>
       </article>

--- a/web/static/blog-weed-control-guide.html
+++ b/web/static/blog-weed-control-guide.html
@@ -1,0 +1,739 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Weed Control for River Parishes Lawns | Xcellent1 Lawn Care Blog</title>
+    <meta name="description" content="Complete Louisiana weed control guide: identify crabgrass, nutsedge, dollarweed & more. Pre-emergent timing for River Parishes, post-emergent calendar, and organic options." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://xcellent1lawncare.com/blog-weed-control-guide" />
+    <meta property="og:title" content="Weed Control for River Parishes Lawns" />
+    <meta property="og:description" content="Complete Louisiana weed control guide: identify crabgrass, nutsedge, dollarweed & more. Pre-emergent timing for River Parishes, post-emergent calendar, and organic options." />
+    <meta property="og:image" content="https://xcellent1lawncare.com/images/product-weed-feed.jpg" />
+    <meta property="article:published_time" content="2025-12-06" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Weed Control for River Parishes Lawns" />
+    <meta name="twitter:description" content="Complete Louisiana weed control guide with identification tables, pre-emergent timing, and monthly treatment calendar." />
+    <link rel="canonical" href="https://xcellent1lawncare.com/blog-weed-control-guide" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon.ico" />
+    <link rel="stylesheet" href="styles.clean.css" />
+    <meta name="theme-color" content="#3b832a" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "Weed Control for River Parishes Lawns",
+        "description": "Complete Louisiana weed control guide with identification tables, pre-emergent timing, and monthly treatment calendar.",
+        "author": { "@type": "Organization", "name": "Xcellent1 Lawn Care" },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Xcellent1 Lawn Care"
+        },
+        "datePublished": "2025-12-06",
+        "mainEntityOfPage": {
+          "@type": "WebPage",
+          "@id": "https://xcellent1lawncare.com/blog-weed-control-guide"
+        }
+      }
+    </script>
+    <style>
+      .blog-hero {
+        background: linear-gradient(135deg, rgba(59, 131, 42, 0.92), rgba(19, 63, 28, 0.96)), url("/images/product-weed-feed.jpg") center/cover;
+        padding: 5rem 1rem;
+        text-align: center;
+        color: #fff;
+      }
+      .blog-hero h1 {
+        font-size: clamp(2rem, 4vw, 3.2rem);
+        margin-bottom: 0.75rem;
+        font-weight: 800;
+        text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+      }
+      .blog-hero .meta {
+        font-size: 0.95rem;
+        opacity: 0.95;
+        display: flex;
+        justify-content: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+      .reading-time {
+        background: rgba(255, 255, 255, 0.2);
+        padding: 0.25rem 0.75rem;
+        border-radius: 20px;
+        font-size: 0.85rem;
+      }
+      .blog-container {
+        max-width: 860px;
+        margin: -3rem auto 0;
+        padding: 0 1rem 2rem;
+        position: relative;
+        z-index: 10;
+      }
+      .blog-content {
+        background: #fff;
+        border-radius: 16px;
+        padding: 2.25rem;
+        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
+      }
+      .blog-content > p:first-of-type {
+        font-size: 1.15rem;
+        color: #4b5563;
+        line-height: 1.8;
+      }
+      .blog-content h2 {
+        color: #166534;
+        margin: 2.5rem 0 1rem;
+        font-size: 1.5rem;
+        position: relative;
+        padding-bottom: 0.5rem;
+      }
+      .blog-content h2::after {
+        content: "";
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 60px;
+        height: 3px;
+        background: linear-gradient(90deg, #22c55e, #3b832a);
+        border-radius: 2px;
+      }
+      .blog-content h3 {
+        color: #166534;
+        margin: 1.75rem 0 0.75rem;
+        font-size: 1.2rem;
+      }
+      .blog-content p, .blog-content li {
+        line-height: 1.8;
+        color: #374151;
+        font-size: 1.02rem;
+      }
+      .blog-content ul {
+        margin: 0.75rem 0 1.5rem;
+        padding-left: 1.25rem;
+      }
+      .weed-table-wrap {
+        overflow-x: auto;
+        margin: 1.5rem 0;
+      }
+      .weed-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.95rem;
+        background: #f9fafb;
+        border-radius: 12px;
+        overflow: hidden;
+      }
+      .weed-table thead {
+        background: linear-gradient(135deg, #166534, #22c55e);
+        color: #fff;
+      }
+      .weed-table th {
+        padding: 0.75rem 1rem;
+        text-align: left;
+        font-weight: 600;
+      }
+      .weed-table td {
+        padding: 0.65rem 1rem;
+        border-bottom: 1px solid #e5e7eb;
+        color: #374151;
+      }
+      .weed-table tbody tr:hover {
+        background: #ecfdf5;
+      }
+      .weed-table .badge {
+        display: inline-block;
+        padding: 0.15rem 0.55rem;
+        border-radius: 999px;
+        font-size: 0.8rem;
+        font-weight: 600;
+      }
+      .weed-table .badge-broadleaf { background: #fef3c7; color: #92400e; }
+      .weed-table .badge-grassy { background: #dbeafe; color: #1e40af; }
+      .weed-table .badge-sedge { background: #fce7f3; color: #9d174d; }
+      .info-box {
+        background: linear-gradient(145deg, #f0fdf4 0%, #dcfce7 100%);
+        border-radius: 12px;
+        padding: 1.5rem;
+        margin: 1.5rem 0;
+        border: 1px solid #86efac;
+      }
+      .info-box h3 {
+        color: #166534;
+        margin: 0 0 0.75rem;
+        font-size: 1.15rem;
+      }
+      .info-box p, .info-box li {
+        color: #15803d;
+      }
+      .warn-box {
+        background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
+        border-left: 4px solid #f59e0b;
+        border-radius: 12px;
+        padding: 1.5rem;
+        margin: 1.5rem 0;
+      }
+      .warn-box h3 {
+        color: #92400e;
+        margin: 0 0 0.75rem;
+        font-size: 1.15rem;
+      }
+      .warn-box p { color: #78350f; margin: 0; }
+      .calendar-box {
+        background: linear-gradient(145deg, #eff6ff 0%, #dbeafe 100%);
+        border-radius: 12px;
+        padding: 1.5rem;
+        margin: 1.5rem 0;
+        border: 1px solid #93c5fd;
+      }
+      .calendar-box h3 {
+        color: #1e40af;
+        margin: 0 0 0.75rem;
+        font-size: 1.15rem;
+      }
+      .calendar-box p { color: #1e3a5f; }
+      .related {
+        border-top: 1px solid #e5e7eb;
+        margin-top: 2rem;
+        padding-top: 1.5rem;
+      }
+      .related a {
+        color: #166534;
+        text-decoration: none;
+        font-weight: 700;
+      }
+      .cta-box {
+        margin-top: 2rem;
+        padding: 1.2rem 1.4rem;
+        border-radius: 14px;
+        background: #f0fdf4;
+        border: 1px solid #bbf7d0;
+      }
+      .cta-box a { color: #14532d; font-weight: 800; }
+      .backlink {
+        display: inline-block;
+        margin-top: 1.5rem;
+        color: #166534;
+        font-weight: 700;
+      }
+      @media (max-width: 640px) {
+        .blog-content { padding: 1.35rem; }
+        .blog-hero { padding: 4rem 1rem 2.5rem; }
+      }
+    </style>
+  </head>
+  <body>
+    <header class="blog-hero">
+      <div class="blog-container">
+        <h1>Weed Control for River Parishes Lawns</h1>
+        <div class="meta">
+          <span>December 2025</span>
+          <span class="reading-time">10 min read</span>
+          <span>Weeds · River Parishes</span>
+        </div>
+      </div>
+    </header>
+
+    <main class="blog-container">
+      <article class="blog-content">
+        <p>
+          Weeds are usually a symptom, not the root problem. If the lawn is thin,
+          underfed, overwatered, or scalped, weeds rush in. The right plan — combining
+          pre-emergent barriers, precise post-emergent timing, and good cultural
+          practices — stops them before they dominate the yard. South Louisiana's
+          long growing season means more weed cycles per year than most regions,
+          so staying ahead of the calendar is everything.
+        </p>
+        <p>
+          This guide covers identification of the weeds most common to the River
+          Parishes, pre-emergent and post-emergent strategies, organic alternatives,
+          and a month-by-month calendar so you always know what to apply and when.
+        </p>
+
+        <h2>Louisiana Weed Identification Guide</h2>
+        <p>
+          Before you treat, know what you are dealing with. Broadleaf weeds,
+          grassy weeds, and sedges each respond to different chemistry. Using
+          the wrong product wastes money and stresses the turf. Refer to the
+          tables below to identify the most common Louisiana lawn weeds.
+        </p>
+
+        <h3>Common Broadleaf Weeds</h3>
+        <p>
+          Broadleaf weeds have wide, net-veined leaves and often produce showy
+          flowers. In the River Parishes these are the most visible (and most
+          frustrating) weeds homeowners face. Most respond well to selective
+          2,4-D / dicamba / MCPP blends applied post-emergent.
+        </p>
+        <div class="weed-table-wrap">
+          <table class="weed-table">
+            <thead>
+              <tr>
+                <th>Weed</th>
+                <th>Appearance</th>
+                <th>Season</th>
+                <th>Control</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><span class="badge badge-broadleaf">Broadleaf</span> Dollarweed</td>
+                <td>Round, penny-sized leaves with scalloped edges; white flowers; likes wet soil</td>
+                <td>Spring through fall</td>
+                <td>Improve drainage; selective broadleaf herbicide; reduces when watering cuts back</td>
+              </tr>
+              <tr>
+                <td><span class="badge badge-broadleaf">Broadleaf</span> Clover (White / Dutch)</td>
+                <td>Three-leaf clusters, small white or pink flowers; low-growing; spreads fast</td>
+                <td>Year-round in Louisiana</td>
+                <td>Broadleaf herbicide with dicamba; improve nitrogen levels (clover thrives in low-N soil)</td>
+              </tr>
+              <tr>
+                <td><span class="badge badge-broadleaf">Broadleaf</span> Henbit</td>
+                <td>Square stems, scalloped opposite leaves, purple-pink tubular flowers</td>
+                <td>Winter annual (emerges fall, flowers spring)</td>
+                <td>Pre-emergent in early fall; post-emergent broadleaf spray in late winter</td>
+              </tr>
+              <tr>
+                <td><span class="badge badge-broadleaf">Broadleaf</span> Chickweed</td>
+                <td>Small oval leaves, slender stems, tiny white star-shaped flowers; forms dense mats</td>
+                <td>Winter annual</td>
+                <td>Pre-emergent (September); post-emergent broadleaf herbicide; hand-pull small patches</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Grassy Weeds</h3>
+        <p>
+          Grassy weeds resemble desirable lawn grasses but grow faster and
+          coarser. They blend into the turf until they outgrow it and become
+          visible as clumps. Grassy weeds require different chemistry than
+          broadleaf herbicides — standard weed-and-feed products will not touch them.
+        </p>
+        <div class="weed-table-wrap">
+          <table class="weed-table">
+            <thead>
+              <tr>
+                <th>Weed</th>
+                <th>Appearance</th>
+                <th>Season</th>
+                <th>Control</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><span class="badge badge-grassy">Grassy</span> Crabgrass</td>
+                <td>Light green, coarse-textured blades; low-growing with radiating stems; seed head resembles crab legs</td>
+                <td>Summer annual</td>
+                <td>Pre-emergent when soil hits 55&deg;F (late Feb-early Mar); post-emergent quinclorac or MSMA in St. Augustine</td>
+              </tr>
+              <tr>
+                <td><span class="badge badge-grassy">Grassy</span> Goosegrass</td>
+                <td>Darker green than crabgrass; flattened stems; white-center seed heads; grows in compacted soil</td>
+                <td>Summer annual</td>
+                <td>Pre-emergent (same timing as crabgrass); reduce compaction; post-emergent Revolver or MSMA</td>
+              </tr>
+              <tr>
+                <td><span class="badge badge-grassy">Grassy</span> Dallisgrass</td>
+                <td>Coarse, thick clumps with prominent midrib; black seed heads; wiry root system</td>
+                <td>Perennial</td>
+                <td>Difficult to control; spot-treat with glyphosate (non-selective) or MSMA; dig out deep roots</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Sedges (Nutgrass / Nutsedge)</h3>
+        <p>
+          Sedges look like grass but are a completely different plant family.
+          They have triangular stems (roll a stem between your fingers — you
+          will feel the edges) and grow faster than lawn grass, often appearing
+          the day after mowing. Standard grassy weed herbicides will not kill
+          sedges. They require dedicated sedge-specific chemistry.
+        </p>
+        <div class="weed-table-wrap">
+          <table class="weed-table">
+            <thead>
+              <tr>
+                <th>Weed</th>
+                <th>Appearance</th>
+                <th>Season</th>
+                <th>Control</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><span class="badge badge-sedge">Sedge</span> Yellow Nutsedge</td>
+                <td>Light yellow-green, glossy leaves; triangular stems; yellow-brown seed heads; tubers (nutlets) on roots</td>
+                <td>Spring through fall</td>
+                <td>Sedgehammer (halosulfuron) when 3-4 inches tall; repeat every 4-6 weeks; do not pull (spreads tubers)</td>
+              </tr>
+              <tr>
+                <td><span class="badge badge-sedge">Sedge</span> Purple Nutsedge</td>
+                <td>Darker green, smaller leaves; purple seed heads; aggressive tuber chain; harder to control than yellow</td>
+                <td>Spring through fall</td>
+                <td>Sedgehammer + surfactant; may need repeat applications; improve drainage</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h2>Pre-emergent Timing for the River Parishes</h2>
+        <p>
+          Pre-emergent herbicides create a chemical barrier in the top layer of
+          soil that kills weed seeds as they germinate. They do not kill existing
+          weeds — you must apply <em>before</em> the seeds sprout. Timing is
+          everything, and in South Louisiana the window is narrower than up north
+          because our soil warms up faster.
+        </p>
+        <p>
+          The key trigger is <strong>soil temperature at 55&deg;F</strong> at a
+          depth of 2-4 inches. For the River Parishes (St. John the Baptist, St.
+          Charles, Ascension parishes), that happens:
+        </p>
+        <ul>
+          <li><strong>Summer weeds (crabgrass, goosegrass):</strong> Apply pre-emergent late February to early March, when forsythia and redbud trees begin blooming. Soil reaches 55&deg;F consistently in this window. A second "split" application 6-8 weeks later extends coverage through the long Louisiana growing season.</li>
+          <li><strong>Winter weeds (henbit, chickweed, annual bluegrass):</strong> Apply pre-emergent in <strong>late September</strong>, when soil temps drop back through 70&deg;F toward 55&deg;F. This stops winter annuals before they establish.</li>
+        </ul>
+
+        <div class="warn-box">
+          <h3>Pre-emergent Pitfall</h3>
+          <p>
+            Do NOT apply pre-emergent if you are seeding or laying sod this
+            spring — the barrier prevents ALL seeds from germinating, including
+            your new grass. Wait until the new turf is fully established (after
+            3-4 mowings) before starting a pre-emergent program.
+          </p>
+        </div>
+
+        <p>
+          For best results, water in the pre-emergent with 1/2 inch of irrigation
+          within 24 hours of application. Do not aerate or dethatch for at least
+          4 weeks after applying, or you will break the chemical barrier and
+          let weeds through.
+        </p>
+
+        <h2>Post-emergent Treatment: Selective vs. Non-selective</h2>
+        <p>
+          When weeds are already visible, you need post-emergent herbicides.
+          These fall into two categories:
+        </p>
+        <ul>
+          <li><strong>Selective herbicides</strong> target specific weed families (broadleaf or grassy) while leaving your lawn grass unharmed. Examples: 2,4-D / dicamba / MCPP blends for broadleaf weeds; quinclorac for crabgrass; sethoxydim for grassy weeds in broadleaf turf.</li>
+          <li><strong>Non-selective herbicides</strong> (glyphosate, glufosinate) kill every green plant they touch. Use ONLY for spot treatment of perennial weeds like dallisgrass or for clearing an area before renovation.</li>
+        </ul>
+
+        <div class="info-box">
+          <h3>Spot Treatment Best Practices</h3>
+          <ul>
+            <li>Use a small pump sprayer or ready-to-use trigger bottle — never broadcast a non-selective product over the whole lawn.</li>
+            <li>Add a non-ionic surfactant (1-2 drops per quart) to help the herbicide stick to waxy leaves.</li>
+            <li>Treat when temperatures are between 60-85&deg;F and no rain is forecast for 24 hours.</li>
+            <li>Do not mow for 2-3 days before or after treatment to give the herbicide time to translocate to the roots.</li>
+            <li>Repeat applications 2-3 weeks apart for stubborn perennial weeds.</li>
+          </ul>
+        </div>
+
+        <h2>Cultural Control: Crowd Out Weeds with a Thicker Lawn</h2>
+        <p>
+          The most effective long-term weed strategy is a lawn so thick and
+          healthy that weed seeds cannot find bare soil to germinate in. This
+          is called <strong>cultural control</strong>, and it beats spraying
+          every time. Three factors matter most:
+        </p>
+
+        <h3>Proper Mowing Height</h3>
+        <p>
+          Mowing too low is the #1 cause of weed invasions in the River Parishes.
+          Scalped grass lets sunlight hit the soil, which triggers weed seed
+          germination. Each grass type has a recommended height range:
+        </p>
+        <ul>
+          <li><strong>St. Augustine:</strong> 3-4 inches — never cut more than 1/3 of the blade at once. See our <a href="blog-mowing-height-guide.html">full mowing height guide</a> for details.</li>
+          <li><strong>Bermuda:</strong> 1-2 inches.</li>
+          <li><strong>Zoysia:</strong> 1.5-2.5 inches.</li>
+          <li><strong>Centipede:</strong> 1.5-2 inches.</li>
+        </ul>
+        <p>
+          Taller grass shades the soil, keeps it cooler, and leaves no room for
+          weed seedlings. It also develops deeper roots, making the lawn more
+          drought-tolerant.
+        </p>
+
+        <h3>Watering Depth</h3>
+        <p>
+          Shallow, frequent watering grows shallow grass roots and creates a
+          perfect environment for dollarweed and sedges. Water <strong>deeply
+          and infrequently</strong>: 1 inch per week (including rainfall) in a
+          single watering or two split applications. Water early in the morning
+          so the turf dries before evening, reducing disease pressure.
+        </p>
+
+        <h3>Fertilization</h3>
+        <p>
+          A properly fed lawn outcompetes weeds naturally. Follow a <a href="blog-fertilizing-guide.html">seasonal fertilizing plan</a> suited to your grass type. Key rules:
+        </p>
+        <ul>
+          <li>Test your soil pH first — Louisiana soils are often acidic; lime may be needed to reach the 6.0-6.5 range.</li>
+          <li>Use slow-release nitrogen: 1 lb of N per 1,000 sq ft per growing month (April-September for warm-season grasses).</li>
+          <li>Do not over-fertilize in spring or fall — excess nitrogen feeds weeds as much as grass.</li>
+          <li>Iron supplements (chelated iron) green up the lawn without pushing excessive growth that weeds exploit.</li>
+        </ul>
+
+        <h2>Organic Weed Control Options</h2>
+        <p>
+          Not every homeowner wants synthetic herbicides. Several organic
+          approaches can keep weed pressure manageable, especially when combined
+          with good cultural practices.
+        </p>
+
+        <h3>Corn Gluten Meal (Pre-emergent)</h3>
+        <p>
+          Corn gluten meal is a natural pre-emergent that inhibits root
+          development in germinating weed seeds. Apply at 20 lbs per 1,000 sq ft
+          in late February (same timing as synthetic pre-emergents) and again in
+          late September for winter weeds. It also provides about 10% nitrogen,
+          giving the lawn a gentle feeding. Be aware: it is less effective than
+          synthetic pre-emergents on heavy weed pressure, and it must stay dry
+          for 3-5 days after application to form the barrier.
+        </p>
+
+        <h3>Vinegar-based Herbicides</h3>
+        <p>
+          Household vinegar (5% acetic acid) is a weak contact killer — it burns
+          the foliage of small annual weeds but rarely kills the roots.
+          Horticultural vinegar (20-30% acetic acid) is more effective but is
+          non-selective and can burn skin. Best use: spot-spray young broadleaf
+          seedlings in sidewalk cracks or bed edges on a sunny day. Reapply
+          every 5-7 days. These products have no soil activity, so they are
+          safe around vegetable gardens.
+        </p>
+
+        <h3>Hand Pulling</h3>
+        <p>
+          For small infestations, nothing beats old-fashioned hand pulling.
+          The best time to pull is after a rain when the soil is soft. Use a
+          weeding tool (dandelion digger or fishtail weeder) to get the entire
+          root system. For nutsedge, <strong>never pull</strong> — you break
+          the tubers off underground and multiply the infestation. Dig nutsedge
+          out with a trowel, removing at least 4 inches of soil around the
+          base.
+        </p>
+
+        <div class="info-box">
+          <h3>Organic Program Summary</h3>
+          <p>
+            Corn gluten meal in February &amp; September + vinegar spot-spray
+            as needed + hand pulling after rain + 3.5-4 inch mowing height = a
+            surprisingly effective organic program for low-to-moderate weed
+            pressure. For heavy infestations, start with targeted synthetic
+            products to knock it down, then maintain organically.
+          </p>
+        </div>
+
+        <h2>Nutsedge: Why It Is Different and How to Beat It</h2>
+        <p>
+          Nutsedge (often called nutgrass) deserves its own section because it
+          is the most misidentified and mistreated weed in Louisiana. It is not
+          a grass — it is a sedge — and the standard lawn herbicides homeowners
+          buy at the big-box store will not touch it.
+        </p>
+
+        <h3>What Makes Nutsedge Unique</h3>
+        <ul>
+          <li><strong>Triangular stem.</strong> Roll a stem between your fingers. If you feel edges, it is a sedge, not grass.</li>
+          <li><strong>Tubers (nutlets).</strong> Nutsedge spreads through underground tubers that can stay dormant for years. Pulling the top breaks the tubers loose, and each piece grows a new plant. This is why pulling makes it worse.</li>
+          <li><strong>Fast growth.</strong> Nutsedge can grow 2 inches in 24 hours after mowing. It outruns the lawn and sticks up above the canopy.</li>
+          <li><strong>Wet-soil indicator.</strong> Nutsedge thrives in poorly drained, wet areas. If you have nutsedge, you likely have a drainage or overwatering issue.</li>
+        </ul>
+
+        <h3>Sedgehammer Application Timing</h3>
+        <p>
+          The most effective product for home lawns is <strong>Sedgehammer
+          (halosulfuron-methyl)</strong>. It is selective — it kills sedges
+          without harming your lawn grass. Follow this protocol:
+        </p>
+        <ul>
+          <li>Apply when nutsedge is <strong>3-4 inches tall</strong> and actively growing (soil temp above 60&deg;F). In the River Parishes, the first application window is mid-April through May.</li>
+          <li>Add a non-ionic surfactant at 0.25% (1 teaspoon per gallon of spray mix) to penetrate the waxy sedge leaf.</li>
+          <li>Spray thoroughly but not to runoff. A single application kills existing plants but may not stop the tubers.</li>
+          <li><strong>Repeat every 4-6 weeks</strong> through the growing season — typically 3-4 applications total. Each round exhausts more tubers.</li>
+          <li>Do not mow for 3 days before or after application so the herbicide translocates to the tuber system.</li>
+        </ul>
+
+        <div class="warn-box">
+          <h3>Bermuda Grass Caution</h3>
+          <p>
+            Sedgehammer is safe for most warm-season grasses (St. Augustine,
+            Bermuda, Zoysia, Centipede) at labeled rates. Do not exceed the
+            labeled rate on Bermuda or Centipede — these are more sensitive.
+            Always read and follow the label.
+          </p>
+        </div>
+
+        <h2>Post-emergent Calendar: What to Use Each Month</h2>
+        <p>
+          Here is a month-by-month guide for active weed control in the River
+          Parishes. Adjust for your specific grass type and the weather each
+          year.
+        </p>
+
+        <div class="calendar-box">
+          <h3>January - February</h3>
+          <p>
+            <strong>Weeds active:</strong> Henbit, chickweed, annual bluegrass (winter
+            annuals). <strong>Action:</strong> Spot-treat with selective broadleaf
+            herbicide (2,4-D / dicamba) on days above 50&deg;F. Do not apply
+            pre-emergent — it is too late for winter weeds, too early for summer.
+            Hand-pull if infestations are small.
+          </p>
+        </div>
+
+        <div class="calendar-box">
+          <h3>March</h3>
+          <p>
+            <strong>Action:</strong> Apply pre-emergent NOW (late Feb-early Mar).
+            Soil temperatures cross 55&deg;F this month. Use prodiamine or
+            dithiopyr for crabgrass and goosegrass. If you missed pre-emergent,
+            use dithiopyr which has some early post-emergent activity on tiny
+            crabgrass seedlings.
+          </p>
+        </div>
+
+        <div class="calendar-box">
+          <h3>April</h3>
+          <p>
+            <strong>Weeds active:</strong> Crabgrass seedlings emerging, dollarweed,
+            clover. <strong>Action:</strong> Spot-treat broadleaf weeds with
+            selective herbicide. Apply first round of Sedgehammer if nutsedge is
+            3-4 inches tall. Split pre-emergent application (6 weeks after first)
+            if you used prodiamine.
+          </p>
+        </div>
+
+        <div class="calendar-box">
+          <h3>May</h3>
+          <p>
+            <strong>Weeds active:</strong> Full summer weed flush — crabgrass,
+            goosegrass, nutsedge, dollarweed. <strong>Action:</strong> Second
+            Sedgehammer application. Spot-treat crabgrass patches with quinclorac.
+            Continue broadleaf spot treatment. Apply post-emergent before weeds
+            exceed 4 inches for best results.
+          </p>
+        </div>
+
+        <div class="calendar-box">
+          <h3>June - July</h3>
+          <p>
+            <strong>Weeds active:</strong> Peak weed season. <strong>Action:</strong>
+            Third Sedgehammer application (if needed). Spot-treat as weeds appear.
+            Avoid spraying in heat above 90&deg;F — herbicide can volatilize and
+            drift, or burn the lawn. Focus on <a href="blog-mowing-height-guide.html">maintaining proper mowing height</a>
+            at 3.5-4 inches to shade out weeds.
+          </p>
+        </div>
+
+        <div class="calendar-box">
+          <h3>August</h3>
+          <p>
+            <strong>Weeds active:</strong> Late summer flush of crabgrass and
+            goosegrass. <strong>Action:</strong> Last call for Sedgehammer if
+            nutsedge is still active. Plan for winter weed pre-emergent — mark
+            your calendar for late September. Do not fertilize yet; wait until
+            the heat breaks.
+          </p>
+        </div>
+
+        <div class="calendar-box">
+          <h3>September - October</h3>
+          <p>
+            <strong>Action:</strong> Apply pre-emergent for winter weeds (henbit,
+            chickweed, annual bluegrass) in late September. Follow
+            <a href="blog-fertilizing-guide.html">fall fertilizing guidelines</a>.
+            Spot-treat any remaining summer broadleaf weeds before they go to
+            seed. This is a good time to core-aerate (after pre-emergent has been
+            down for 4+ weeks, or before applying it).
+          </p>
+        </div>
+
+        <div class="calendar-box">
+          <h3>November - December</h3>
+          <p>
+            <strong>Weeds active:</strong> Winter annuals emerging. <strong>Action:</strong>
+            Spot-treat winter broadleaf weeds with 2,4-D / dicamba on mild days.
+            Mulch fallen leaves instead of bagging — returning organic matter
+            feeds the soil. Do heavy cleanup of bed edges and fence lines where
+            weeds re-seed first.
+          </p>
+        </div>
+
+        <h2>Building a Complete Weed Management Plan</h2>
+        <p>
+          A successful weed control program in the River Parishes layers all the
+          strategies above into a year-round system:
+        </p>
+        <ol>
+          <li><strong>Know your grass type.</strong> Different grasses tolerate
+          different herbicides. Identify yours with our <a href="blog-grass-types.html">grass type guide</a>.</li>
+          <li><strong>Pre-emergent in spring and fall.</strong> Late February and
+          late September — never skip these two applications.</li>
+          <li><strong>Mow at the right height.</strong> 3.5-4 inches for St. Augustine
+          crowds out more weeds than any chemical can. Read our <a href="blog-mowing-height-guide.html">mowing height guide</a>.</li>
+          <li><strong>Fertilize on schedule.</strong> A <a href="blog-fertilizing-guide.html">seasonal fertilizing plan</a>
+          keeps the lawn dense and competitive against weeds.</li>
+          <li><strong>Spot-treat early.</strong> Do not wait until weeds have
+          gone to seed. A 2-second spray on a single weed today prevents 5,000
+          seeds next season.</li>
+          <li><strong>Water correctly.</strong> Deep, infrequent watering (1 inch
+          per week) discourages dollarweed and nutsedge.</li>
+          <li><strong>Monitor bed edges and fence lines.</strong> Weeds always
+          start at the margin and move inward. Pre-emergent granules on these
+          borders in spring and fall stop the invasion before it crosses into
+          the turf.</li>
+        </ol>
+
+        <p>
+          Also check our <a href="blog-pest-disease-guide.html">pest and disease guide</a>
+          for issues like chinch bugs and brown patch that weaken the turf and
+          invite weeds. A healthy lawn resists both pests and weeds.
+        </p>
+
+        <h2>When to Call a Professional</h2>
+        <p>
+          If you are making 3+ herbicide applications per season and the weed
+          pressure is not declining, or if you have large areas overtaken by
+          nutsedge, dallisgrass, or perennial weeds, it is time for professional
+          help. Professional applicators have access to products (like Certainty,
+          Monument, and Celsius) that are not available to homeowners, and they
+          can calibrate rates precisely for your grass type.
+        </p>
+
+        <div class="cta-box">
+          <p><strong>Stop fighting weeds — get a professional weed control program from Xcellent1 Lawn Care.</strong></p>
+          <p>
+            Our crew services the River Parishes with custom weed management
+            plans tailored to your grass type, property size, and weed pressure.
+            We use commercial-grade products and calibrated application
+            schedules so you get results without the guesswork.
+          </p>
+          <p>
+            <a href="home.html#waitlist">Request a Free Quote</a> ·
+            <a href="careers.html">Join the Crew</a> ·
+            <a href="/blog">Back to Blog Hub</a>
+          </p>
+        </div>
+
+        <div class="related">
+          <h2>Related reading</h2>
+          <ul>
+            <li><a href="blog-grass-types.html">Best Grass Types for Louisiana Lawns</a></li>
+            <li><a href="blog-mowing-height-guide.html">Lawn Mowing Height Guide</a></li>
+            <li><a href="blog-pest-disease-guide.html">Pest &amp; Disease Guide for River Parishes Lawns</a></li>
+          </ul>
+        </div>
+        <a class="backlink" href="/blog">&larr; Back to the South Louisiana Blog Hub</a>
+      </article>
+    </main>
+  </body>
+</html>

--- a/web/static/blog.html
+++ b/web/static/blog.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Lawn Care Blog | Xcellent1 Lawn Care — River Parishes, LA</title>
+  <meta name="description" content="Expert lawn care guides for South Louisiana homeowners. Grass types, mowing, fertilizing, weed control, watering, and seasonal tips for the River Parishes." />
+  <meta name="robots" content="index, follow, max-image-preview:large" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Xcellent1 Lawn Care" />
+  <meta property="og:url" content="https://xcellent1lawncare.com/blog" />
+  <meta property="og:title" content="Lawn Care Blog | Xcellent1 Lawn Care" />
+  <meta property="og:description" content="Expert lawn care guides for South Louisiana homeowners. Grass types, mowing, fertilizing, weed control, watering, and seasonal tips." />
+  <meta property="og:image" content="https://xcellent1lawncare.com/images/xcellent1-logo-transparent.png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:locale" content="en_US" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Lawn Care Blog | Xcellent1 Lawn Care" />
+  <meta name="twitter:description" content="Expert lawn care guides for South Louisiana homeowners." />
+  <meta name="twitter:image" content="https://xcellent1lawncare.com/images/xcellent1-logo-transparent.png" />
+  <link rel="canonical" href="https://xcellent1lawncare.com/blog" />
+  <link rel="icon" type="image/png" sizes="32x32" href="images/favicon.ico" />
+  <link rel="stylesheet" href="styles.clean.css" />
+  <meta name="theme-color" content="#3b832a" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Blog",
+    "name": "Xcellent1 Lawn Care Blog",
+    "description": "Expert lawn care guides for South Louisiana homeowners.",
+    "url": "https://xcellent1lawncare.com/blog",
+    "publisher": {
+      "@type": "Organization",
+      "name": "Xcellent1 Lawn Care",
+      "url": "https://xcellent1lawncare.com"
+    }
+  }
+  </script>
+  <style>
+    .blog-index-hero {
+      background: linear-gradient(135deg, rgba(22, 101, 52, 0.95), rgba(16, 185, 129, 0.85)), url("images/lawnservices.jpg") center/cover;
+      padding: 5rem 1rem 4rem;
+      text-align: center;
+      color: #fff;
+    }
+    .blog-index-hero h1 { font-size: 2.75rem; margin-bottom: 0.75rem; font-weight: 700; text-shadow: 0 2px 10px rgba(0,0,0,0.2); }
+    .blog-index-hero p { font-size: 1.15rem; opacity: 0.95; max-width: 600px; margin: 0 auto; }
+    .blog-index-container { max-width: 1100px; margin: 0 auto; padding: 2rem 1rem 4rem; }
+    .category-tabs { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 2rem; justify-content: center; }
+    .category-tab { padding: 0.5rem 1.25rem; border-radius: 20px; border: 2px solid #e5e7eb; background: #fff; cursor: pointer; font-size: 0.9rem; font-weight: 500; transition: all 0.2s; color: #374151; }
+    .category-tab:hover { border-color: #10b981; color: #10b981; }
+    .category-tab.active { background: #10b981; color: #fff; border-color: #10b981; }
+    .blog-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 1.5rem; }
+    .blog-card { background: #fff; border-radius: 16px; overflow: hidden; box-shadow: 0 4px 20px rgba(0,0,0,0.08); transition: all 0.3s; border: 1px solid #e5e7eb; }
+    .blog-card:hover { transform: translateY(-4px); box-shadow: 0 12px 40px rgba(0,0,0,0.12); }
+    .blog-card-image { height: 200px; background-size: cover; background-position: center; display: flex; align-items: flex-start; padding: 0.75rem; }
+    .blog-card-tag { display: inline-block; padding: 0.25rem 0.75rem; border-radius: 12px; font-size: 0.8rem; font-weight: 600; background: rgba(255,255,255,0.9); color: #047857; }
+    .blog-card-body { padding: 1.25rem; }
+    .blog-card-meta { display: flex; gap: 1rem; font-size: 0.85rem; color: #6b7280; margin-bottom: 0.5rem; }
+    .blog-card h2 { font-size: 1.2rem; margin: 0 0 0.5rem; line-height: 1.4; }
+    .blog-card h2 a { color: #1f2937; text-decoration: none; }
+    .blog-card h2 a:hover { color: #10b981; }
+    .blog-card p { color: #6b7280; font-size: 0.95rem; line-height: 1.6; margin: 0 0 1rem; }
+    .blog-card .read-more { color: #10b981; font-weight: 600; text-decoration: none; display: inline-flex; align-items: center; gap: 0.25rem; font-size: 0.95rem; }
+    .blog-card .read-more:hover { gap: 0.5rem; }
+    .blog-card.featured { grid-column: 1 / -1; display: grid; grid-template-columns: 1fr 1fr; }
+    .blog-card.featured .blog-card-image { height: 100%; min-height: 300px; }
+    .blog-card.featured .blog-card-body { padding: 2rem; display: flex; flex-direction: column; justify-content: center; }
+    .blog-card.featured h2 { font-size: 1.5rem; }
+    @media (max-width: 768px) {
+      .blog-index-hero h1 { font-size: 2rem; }
+      .blog-grid { grid-template-columns: 1fr; }
+      .blog-card.featured { grid-template-columns: 1fr; }
+      .blog-card.featured .blog-card-image { min-height: 200px; }
+    }
+  </style>
+</head>
+<body>
+  <nav class="navbar">
+    <div class="navbar-brand">
+      <img src="images/xcellent1-logo-transparent.png" alt="Xcellent1 logo" class="navbar-logo" />
+      <div class="navbar-title">
+        <span class="navbar-name">XCELLENT1</span>
+        <span class="navbar-tagline">LAWN CARE</span>
+      </div>
+    </div>
+    <div class="navbar-links">
+      <a href="home.html" class="navbar-link">Home</a>
+      <a href="shop.html" class="navbar-link">Shop</a>
+      <a href="careers.html" class="navbar-link">Careers</a>
+      <a href="login.html" class="navbar-login">Login</a>
+    </div>
+  </nav>
+
+  <header class="blog-index-hero">
+    <h1>📖 Lawn Care Blog</h1>
+    <p>Expert guides for South Louisiana homeowners — from the pros at Xcellent1 Lawn Care</p>
+  </header>
+
+  <div class="blog-index-container">
+
+    <!-- Category Tabs -->
+    <div class="category-tabs">
+      <span class="category-tab active" data-cat="all">All Guides</span>
+      <span class="category-tab" data-cat="grass">Grass &amp; Soil</span>
+      <span class="category-tab" data-cat="seasonal">Seasonal</span>
+      <span class="category-tab" data-cat="maintenance">Maintenance</span>
+      <span class="category-tab" data-cat="installation">Installation</span>
+    </div>
+
+    <!-- Blog Grid -->
+    <div class="blog-grid" id="blogGrid">
+
+      <!-- FEATURED: Grass Types -->
+      <article class="blog-card featured" data-cat="grass">
+        <div class="blog-card-image" style="background-image: url('https://images.unsplash.com/photo-1558904541-efa843a96f01?w=800&amp;q=80')">
+          <span class="blog-card-tag">🌿 Grass &amp; Soil</span>
+        </div>
+        <div class="blog-card-body">
+          <div class="blog-card-meta"><span>📅 November 2025</span><span>📖 12 min read</span></div>
+          <h2><a href="blog-grass-types.html">Best Grass Types for LaPlace, Louisiana</a></h2>
+          <p>St. Augustine, Bermuda, Zoysia, and Centipede — which warm-season grass is right for your River Parishes lawn? Compare shade tolerance, drought resistance, maintenance needs, and cost.</p>
+          <a href="blog-grass-types.html" class="read-more">Read Full Guide →</a>
+        </div>
+      </article>
+
+      <!-- Seasonal Tips -->
+      <article class="blog-card" data-cat="seasonal">
+        <div class="blog-card-image" style="background-image: url('https://images.unsplash.com/photo-1592419044706-39796d40f98c?w=800&amp;q=80')">
+          <span class="blog-card-tag">🌸 Seasonal</span>
+        </div>
+        <div class="blog-card-body">
+          <div class="blog-card-meta"><span>📅 November 2025</span><span>📖 8 min read</span></div>
+          <h2><a href="blog-seasonal-tips.html">Seasonal Lawn Care Tips for Louisiana</a></h2>
+          <p>Month-by-month lawn care calendar for the River Parishes. What to do in spring, summer, fall, and winter to keep your lawn thriving year-round.</p>
+          <a href="blog-seasonal-tips.html" class="read-more">Read Full Guide →</a>
+        </div>
+      </article>
+
+      <!-- Watering Guide -->
+      <article class="blog-card" data-cat="maintenance">
+        <div class="blog-card-image" style="background-image: url('https://images.unsplash.com/photo-1558618666-fcd25c85f82e?w=800&amp;q=80')">
+          <span class="blog-card-tag">💧 Maintenance</span>
+        </div>
+        <div class="blog-card-body">
+          <div class="blog-card-meta"><span>📅 November 2025</span><span>📖 8 min read</span></div>
+          <h2><a href="blog-watering-guide.html">Louisiana Lawn Watering Guide</a></h2>
+          <p>Deep watering 1-2x per week beats daily sprinkling. Learn when, how long, and how much to water your South Louisiana lawn for deep root growth.</p>
+          <a href="blog-watering-guide.html" class="read-more">Read Full Guide →</a>
+        </div>
+      </article>
+
+      <!-- Fertilizing Guide -->
+      <article class="blog-card" data-cat="maintenance">
+        <div class="blog-card-image" style="background-image: url('https://images.unsplash.com/photo-1585320806297-9794b3e4eeae?w=800&amp;q=80')">
+          <span class="blog-card-tag">🧪 Maintenance</span>
+        </div>
+        <div class="blog-card-body">
+          <div class="blog-card-meta"><span>📅 November 2025</span><span>📖 10 min read</span></div>
+          <h2><a href="blog-fertilizing-guide.html">How to Fertilize a Louisiana Lawn</a></h2>
+          <p>Soil testing, N-P-K ratios, application timing, and organic options for warm-season grasses in South Louisiana's humid climate.</p>
+          <a href="blog-fertilizing-guide.html" class="read-more">Read Full Guide →</a>
+        </div>
+      </article>
+
+      <!-- Mowing Guide -->
+      <article class="blog-card" data-cat="maintenance">
+        <div class="blog-card-image" style="background-image: url('https://images.unsplash.com/photo-1536657464919-892534f60c6c?w=800&amp;q=80')">
+          <span class="blog-card-tag">✂️ Maintenance</span>
+        </div>
+        <div class="blog-card-body">
+          <div class="blog-card-meta"><span>📅 November 2025</span><span>📖 8 min read</span></div>
+          <h2><a href="blog-mowing-height-guide.html">Mowing Height &amp; Edging for South Louisiana Lawns</a></h2>
+          <p>Cut height, frequency, edging, and blade sharpness — the right mowing habits keep St. Augustine and Bermuda thick and weed-resistant.</p>
+          <a href="blog-mowing-height-guide.html" class="read-more">Read Full Guide →</a>
+        </div>
+      </article>
+
+      <!-- Weed Control -->
+      <article class="blog-card" data-cat="maintenance">
+        <div class="blog-card-image" style="background-image: url('https://images.unsplash.com/photo-1559561853-2cf7a5a6d1b1?w=800&amp;q=80')">
+          <span class="blog-card-tag">🌱 Maintenance</span>
+        </div>
+        <div class="blog-card-body">
+          <div class="blog-card-meta"><span>📅 November 2025</span><span>📖 9 min read</span></div>
+          <h2><a href="blog-weed-control-guide.html">Weed Control for River Parishes Lawns</a></h2>
+          <p>Crabgrass, nutsedge, dollarweed, and broadleaf weeds — identification, pre-emergent timing, and post-emergent treatment for South Louisiana.</p>
+          <a href="blog-weed-control-guide.html" class="read-more">Read Full Guide →</a>
+        </div>
+      </article>
+
+      <!-- Pest & Disease -->
+      <article class="blog-card" data-cat="maintenance">
+        <div class="blog-card-image" style="background-image: url('https://images.unsplash.com/photo-1625245490954-2c1f2a92a0f5?w=800&amp;q=80')">
+          <span class="blog-card-tag">🐛 Maintenance</span>
+        </div>
+        <div class="blog-card-body">
+          <div class="blog-card-meta"><span>📅 November 2025</span><span>📖 8 min read</span></div>
+          <h2><a href="blog-pest-disease-guide.html">Pest &amp; Disease Guide for Louisiana Lawns</a></h2>
+          <p>Chinch bugs, armyworms, grubs, brown patch, and large patch — spot the signs and treat before these common South Louisiana lawn problems spread.</p>
+          <a href="blog-pest-disease-guide.html" class="read-more">Read Full Guide →</a>
+        </div>
+      </article>
+
+      <!-- Shade & Drainage -->
+      <article class="blog-card" data-cat="grass">
+        <div class="blog-card-image" style="background-image: url('https://images.unsplash.com/photo-1500382017468-9049fed747ef?w=800&amp;q=80')">
+          <span class="blog-card-tag">🌳 Grass &amp; Soil</span>
+        </div>
+        <div class="blog-card-body">
+          <div class="blog-card-meta"><span>📅 November 2025</span><span>📖 7 min read</span></div>
+          <h2><a href="blog-shade-drainage-guide.html">Shade, Drainage &amp; Tree Competition in Louisiana Lawns</a></h2>
+          <p>Fix the problems that kill grass in South Louisiana: shade from live oaks, poor drainage, tree root competition, and compacted soil.</p>
+          <a href="blog-shade-drainage-guide.html" class="read-more">Read Full Guide →</a>
+        </div>
+      </article>
+
+      <!-- Sod Installation -->
+      <article class="blog-card" data-cat="installation">
+        <div class="blog-card-image" style="background-image: url('https://images.unsplash.com/photo-1558618666-fcd25c85f82e?w=800&amp;q=80')">
+          <span class="blog-card-tag">🟢 Installation</span>
+        </div>
+        <div class="blog-card-body">
+          <div class="blog-card-meta"><span>📅 November 2025</span><span>📖 8 min read</span></div>
+          <h2><a href="blog-sod-installation-guide.html">Sod Installation Guide for South Louisiana</a></h2>
+          <p>When sod makes sense, how to prep the yard, install it correctly, and keep new sod alive through a Louisiana summer.</p>
+          <a href="blog-sod-installation-guide.html" class="read-more">Read Full Guide →</a>
+        </div>
+      </article>
+
+      <!-- Storm Recovery -->
+      <article class="blog-card" data-cat="seasonal">
+        <div class="blog-card-image" style="background-image: url('https://images.unsplash.com/photo-1547683905-f686c993aae5?w=800&amp;q=80')">
+          <span class="blog-card-tag">⛈️ Seasonal</span>
+        </div>
+        <div class="blog-card-body">
+          <div class="blog-card-meta"><span>📅 November 2025</span><span>📖 7 min read</span></div>
+          <h2><a href="blog-storm-recovery-guide.html">Storm Recovery &amp; Cleanup for South Louisiana Lawns</a></h2>
+          <p>How to clean up debris, manage flooding, deal with saltwater intrusion, and help your lawn recover after hurricanes and heavy storms.</p>
+          <a href="blog-storm-recovery-guide.html" class="read-more">Read Full Guide →</a>
+        </div>
+      </article>
+
+    </div>
+  </div>
+
+  <footer class="blog-footer">
+    <p><strong>© 2025 Xcellent1 Lawn Care</strong></p>
+    <p style="font-size: 0.9rem; opacity: 0.8">Serving the River Parishes, Louisiana</p>
+  </footer>
+
+  <script>
+    // Category filtering
+    document.querySelectorAll('.category-tab').forEach(tab => {
+      tab.addEventListener('click', function() {
+        document.querySelectorAll('.category-tab').forEach(t => t.classList.remove('active'));
+        this.classList.add('active');
+        const cat = this.dataset.cat;
+        document.querySelectorAll('#blogGrid .blog-card').forEach(card => {
+          if (cat === 'all' || card.dataset.cat === cat) {
+            card.style.display = '';
+          } else {
+            card.style.display = 'none';
+          }
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/web/static/home.html
+++ b/web/static/home.html
@@ -513,7 +513,7 @@
   <section id="blog" class="blog-section">
     <div class="section-header">
       <h2>Lawn Care Tips & Advice</h2>
-      <p>Free tips to keep your Louisiana lawn looking its best</p>
+      <p>Expert guides for South Louisiana homeowners — from the pros at Xcellent1</p>
     </div>
     <div class="blog-grid">
       <article class="blog-card">
@@ -523,15 +523,9 @@
           <div class="blog-date">November 2025</div>
           <h3 class="blog-title">Best Grass Types for LaPlace, Louisiana</h3>
           <p class="blog-excerpt">
-            St. Augustine, Bermuda, Zoysia, and Centipede grass thrive in
-            LaPlace's humid climate.
+            St. Augustine, Bermuda, Zoysia, and Centipede — which grass is right for your River Parishes lawn?
           </p>
-          <!-- removed nested navbar; global navbar at page top is authoritative -->
-          <p class="blog-excerpt">
-            Deep watering 1-2x/week beats daily sprinkling. Water early
-            morning.
-          </p>
-          <a href="blog-watering-guide.html" class="read-more">Read More &rarr;</a>
+          <a href="blog-grass-types.html" class="read-more">Read More &rarr;</a>
         </div>
       </article>
       <article class="blog-card">
@@ -539,14 +533,28 @@
         </div>
         <div class="blog-content">
           <div class="blog-date">November 2025</div>
-          <h3 class="blog-title">Seasonal Lawn Care Tips</h3>
+          <h3 class="blog-title">Seasonal Lawn Care Tips for Louisiana</h3>
           <p class="blog-excerpt">
-            Learn how to keep your lawn healthy and beautiful through all four
-            seasons in Louisiana.
+            Month-by-month lawn care calendar for the River Parishes. Spring through winter.
           </p>
           <a href="blog-seasonal-tips.html" class="read-more">Read More &rarr;</a>
         </div>
       </article>
+      <article class="blog-card">
+        <div class="blog-image" data-bg="https://images.unsplash.com/photo-1558618666-fcd25c85f82e?w=800&amp;q=80">
+        </div>
+        <div class="blog-content">
+          <div class="blog-date">November 2025</div>
+          <h3 class="blog-title">Louisiana Lawn Watering Guide</h3>
+          <p class="blog-excerpt">
+            Deep watering 1-2x/week beats daily sprinkling. Water early morning.
+          </p>
+          <a href="blog-watering-guide.html" class="read-more">Read More &rarr;</a>
+        </div>
+      </article>
+    </div>
+    <div style="text-align: center; margin-top: 2rem;">
+      <a href="blog.html" class="btn" style="display: inline-block;">View All Guides &rarr;</a>
     </div>
   </section>
 


### PR DESCRIPTION
## What changed

- **New blog index page** at /blog with category filtering by topic (Grass & Soil, Seasonal, Maintenance, Installation)
- **7 blog posts expanded** from 7-8KB to 28-38KB each with comprehensive content, tables, checklists, and expert guidance
- **Mowing guide** expanded from 7.5KB to 16KB with grass-type height table
- **Related posts sections** added to all 10 blog posts with 3 internal links each
- **Homepage blog section** rewritten to show 3 featured posts + link to full blog index
- **Fixed /static/ image paths** in 7 newer blog posts
- **Internal cross-linking** between related posts throughout the blog

## File stats
11 blog files, 284KB total, 4,050 lines added