### PR TITLE
fix(seo): clean homepage title (embedded newlines + too long)

### DIFF
--- a/web/static/home.html
+++ b/web/static/home.html
@@ -4,10 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>
-    Xcellent1 Lawn Care | Professional Lawn Services in LaPlace & River
-    Parishes, LA
-  </title>
+  <title>Lawn Care in LaPlace & River Parishes, LA | Xcellent1</title>
   <meta name="description"
     content="Xcellent1 Lawn Care offers professional lawn mowing, edging, trimming & landscaping in LaPlace, Reserve, Garyville & the River Parishes, Louisiana. Licensed & insured. Free quotes. Call (504) 875-8079." />
   <meta name="keywords"

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -4,10 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>
-    Xcellent1 Lawn Care | Professional Lawn Services in LaPlace & River
-    Parishes, LA
-  </title>
+  <title>Lawn Care in LaPlace & River Parishes, LA | Xcellent1</title>
   <meta name="description"
     content="Xcellent1 Lawn Care offers professional lawn mowing, edging, trimming & landscaping in LaPlace, Reserve, Garyville & the River Parishes, Louisiana. Licensed & insured. Free quotes. Call (504) 875-8079." />
   <meta name="keywords"


### PR DESCRIPTION
## What
The live homepage `<title>` is 92 chars **with embedded newlines and indentation**:
```
<title>
    Xcellent1 Lawn Care | Professional Lawn Services in LaPlace & River
    Parishes, LA
  </title>
```
Google reads the raw title and truncates ~60 chars, so this displays poorly in search results.

Replaced with a single **53-char, keyword-first** local title on both identical homepages (`index.html` + `home.html`):
`Lawn Care in LaPlace & River Parishes, LA | Xcellent1`

Leads with the primary local-search phrase (service + location), brand at the end. OG/Twitter titles were already clean single-lines — untouched.

## Deploy
Ships via the working GitHub Actions `deploy-cloudflare.yml` on merge to `main`. (Note: the native "Workers Builds" check fails pre-existingly — see #49.)

_Kept separate from #49 (security headers) per single-concern PRs. Same fix also applied to the `chore/llms-txt` redesign branch so it isn't reintroduced on that merge._