### PR TITLE
🎨 Palette: Improve accessibility and keyboard navigation for service cards and modal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,3 @@
-## 2026-07-14 - Standardizing Modal Accessibility
-**Learning:** Standard modal accessibility for the repository requires role="dialog", aria-modal="true", an Escape key listener, and focus management (focusing the first input on open and restoring focus to the trigger on close). Non-semantic interactive elements like divs used as buttons must have role="button" and tabindex="0" to be discoverable by screen readers and navigable by keyboard.
-**Action:** Always include ARIA roles and focus management when implementing or improving modals or custom interactive components.
+## 2026-07-14 - Standardizing Modal and Menu Accessibility
+**Learning:** Standard modal accessibility for the repository requires role="dialog", aria-modal="true", an Escape key listener, and focus management (focusing the first input on open and restoring focus to the trigger on close). Mobile menu toggles must include aria-expanded attributes on the trigger button, which should be updated programmatically in JavaScript when the menu state changes. Non-semantic interactive elements like divs used as buttons must have role="button" and tabindex="0" to be discoverable by screen readers and navigable by keyboard.
+**Action:** Always include ARIA roles, aria-expanded for toggles, and robust focus management when implementing or improving interactive components.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-14 - Standardizing Modal Accessibility
+**Learning:** Standard modal accessibility for the repository requires role="dialog", aria-modal="true", an Escape key listener, and focus management (focusing the first input on open and restoring focus to the trigger on close). Non-semantic interactive elements like divs used as buttons must have role="button" and tabindex="0" to be discoverable by screen readers and navigable by keyboard.
+**Action:** Always include ARIA roles and focus management when implementing or improving modals or custom interactive components.

--- a/web/static/home.html
+++ b/web/static/home.html
@@ -497,7 +497,7 @@
       </p>
     </div>
     <div class="services-grid">
-      <div class="service-card" onclick="openServiceModal('Weekly Lawn Maintenance')">
+      <div class="service-card" onclick="openServiceModal('Weekly Lawn Maintenance')" role="button" tabindex="0">
         <div class="service-image bg-service-lawn" role="img" aria-label="Weekly Lawn Maintenance">
           <noscript>
             <img src="images/lawnservices.jpg" alt="Weekly Lawn Maintenance" />
@@ -516,7 +516,7 @@
           </p>
         </div>
       </div>
-      <div class="service-card" onclick="openServiceModal('Flower Bed Clean Out & Weed Removal')">
+      <div class="service-card" onclick="openServiceModal('Flower Bed Clean Out & Weed Removal')" role="button" tabindex="0">
         <div class="service-image bg-service-flowerbed" role="img" aria-label="Flower Bed Clean Out & Weed Removal">
           <noscript>
             <img src="images/flowerbedcleanup.webp" alt="Flower Bed Clean Out & Weed Removal" />
@@ -535,7 +535,7 @@
           </p>
         </div>
       </div>
-      <div class="service-card" onclick="openServiceModal('Spring Cleaning')" style="cursor: pointer">
+      <div class="service-card" onclick="openServiceModal('Spring Cleaning')" style="cursor: pointer" role="button" tabindex="0">
         <div class="service-image bg-service-spring" role="img" aria-label="Spring Cleaning">
           <noscript>
             <img src="images/springcleaning.webp" alt="Spring Cleaning" />
@@ -554,7 +554,7 @@
           </p>
         </div>
       </div>
-      <div class="service-card" onclick="openServiceModal('Leaf & Debris Removal')" style="cursor: pointer">
+      <div class="service-card" onclick="openServiceModal('Leaf & Debris Removal')" style="cursor: pointer" role="button" tabindex="0">
         <div class="service-image bg-service-leaf" role="img" aria-label="Leaf & Debris Removal">
           <noscript>
             <img src="images/lawnservices.jpg" alt="Leaf & Debris Removal" />
@@ -573,7 +573,7 @@
           </p>
         </div>
       </div>
-      <div class="service-card" onclick="openServiceModal('Tractor / Bush Hog Services')" style="cursor: pointer">
+      <div class="service-card" onclick="openServiceModal('Tractor / Bush Hog Services')" style="cursor: pointer" role="button" tabindex="0">
         <div class="service-image bg-service-bushhog" role="img" aria-label="Tractor / Bush Hog Services">
           <noscript>
             <img src="images/bushhog.webp" alt="Tractor / Bush Hog Services" />
@@ -914,13 +914,13 @@
 
 
   <!-- Service Inquiry Modal -->
-  <div id="service-modal" class="modal">
+  <div id="service-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-service-title">
     <div class="modal-content">
       <div class="modal-header">
         <h2 id="modal-service-title">
           Request Service
         </h2>
-        <button onclick="closeServiceModal()" class="modal-close">
+        <button onclick="closeServiceModal()" class="modal-close" aria-label="Close">
           &times;
         </button>
       </div>
@@ -1045,17 +1045,25 @@
   </footer>
 
   <script>
+    let lastFocusedElement;
+
     function openServiceModal(serviceName) {
+      lastFocusedElement = document.activeElement;
       document.getElementById("modal-service-title").textContent =
         serviceName;
       document.getElementById("inquiry-service").value = serviceName;
       const modal = document.getElementById("service-modal");
       modal.style.display = "flex";
+      modal.classList.add("active");
+      document.getElementById("firstName").focus();
     }
 
     function closeServiceModal() {
-      document.getElementById("service-modal").style.display = "none";
+      const modal = document.getElementById("service-modal");
+      modal.style.display = "none";
+      modal.classList.remove("active");
       document.getElementById("service-inquiry-form").reset();
+      if (lastFocusedElement) lastFocusedElement.focus();
     }
 
     function handleServiceInquiry(e) {
@@ -1096,6 +1104,22 @@
         }
       });
 
+    // Close on Escape
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" && document.getElementById("service-modal").style.display === "flex") {
+        closeServiceModal();
+      }
+    });
+
+    // Keyboard support for service cards
+    document.querySelectorAll('.service-card').forEach(card => {
+      card.addEventListener('keydown', e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          card.click();
+        }
+      });
+    });
   </script>
   <script>
     document.addEventListener("DOMContentLoaded", function () {

--- a/web/static/home.html
+++ b/web/static/home.html
@@ -378,7 +378,7 @@
         <span class="navbar-tagline">LAWN CARE</span>
       </div>
     </div>
-    <button class="mobile-menu-btn" onclick="toggleMobileMenu()" aria-label="Toggle menu">
+    <button class="mobile-menu-btn" onclick="toggleMobileMenu()" aria-label="Toggle menu" aria-expanded="false">
       ☰
     </button>
     <div class="navbar-links" id="navbar-links">
@@ -1060,6 +1060,7 @@
 
     function closeServiceModal() {
       const modal = document.getElementById("service-modal");
+      if (!modal.classList.contains("active")) return;
       modal.style.display = "none";
       modal.classList.remove("active");
       document.getElementById("service-inquiry-form").reset();
@@ -1106,7 +1107,7 @@
 
     // Close on Escape
     document.addEventListener("keydown", function (e) {
-      if (e.key === "Escape" && document.getElementById("service-modal").style.display === "flex") {
+      if (e.key === "Escape") {
         closeServiceModal();
       }
     });
@@ -1136,17 +1137,17 @@
   <script>
     // Mobile menu toggle
     function toggleMobileMenu() {
-      document.getElementById("navbar-links").classList.toggle(
-        "active",
-      );
+      const links = document.getElementById("navbar-links");
+      const btn = document.querySelector(".mobile-menu-btn");
+      const isActive = links.classList.toggle("active");
+      btn.setAttribute("aria-expanded", isActive);
     }
 
     // Close mobile menu when clicking a link
     document.querySelectorAll(".navbar-link").forEach((link) => {
       link.addEventListener("click", () => {
-        document.getElementById("navbar-links").classList.remove(
-          "active",
-        );
+        document.getElementById("navbar-links").classList.remove("active");
+        document.querySelector(".mobile-menu-btn").setAttribute("aria-expanded", "false");
       });
     });
 

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -497,7 +497,7 @@
       </p>
     </div>
     <div class="services-grid">
-      <div class="service-card" onclick="openServiceModal('Weekly Lawn Maintenance')">
+      <div class="service-card" onclick="openServiceModal('Weekly Lawn Maintenance')" role="button" tabindex="0">
         <div class="service-image bg-service-lawn" role="img" aria-label="Weekly Lawn Maintenance">
           <noscript>
             <img src="images/lawnservices.jpg" alt="Weekly Lawn Maintenance" />
@@ -516,7 +516,7 @@
           </p>
         </div>
       </div>
-      <div class="service-card" onclick="openServiceModal('Flower Bed Clean Out & Weed Removal')">
+      <div class="service-card" onclick="openServiceModal('Flower Bed Clean Out & Weed Removal')" role="button" tabindex="0">
         <div class="service-image bg-service-flowerbed" role="img" aria-label="Flower Bed Clean Out & Weed Removal">
           <noscript>
             <img src="images/flowerbedcleanup.webp" alt="Flower Bed Clean Out & Weed Removal" />
@@ -535,7 +535,7 @@
           </p>
         </div>
       </div>
-      <div class="service-card" onclick="openServiceModal('Spring Cleaning')" style="cursor: pointer">
+      <div class="service-card" onclick="openServiceModal('Spring Cleaning')" style="cursor: pointer" role="button" tabindex="0">
         <div class="service-image bg-service-spring" role="img" aria-label="Spring Cleaning">
           <noscript>
             <img src="images/springcleaning.webp" alt="Spring Cleaning" />
@@ -554,7 +554,7 @@
           </p>
         </div>
       </div>
-      <div class="service-card" onclick="openServiceModal('Leaf & Debris Removal')" style="cursor: pointer">
+      <div class="service-card" onclick="openServiceModal('Leaf & Debris Removal')" style="cursor: pointer" role="button" tabindex="0">
         <div class="service-image bg-service-leaf" role="img" aria-label="Leaf & Debris Removal">
           <noscript>
             <img src="images/lawnservices.jpg" alt="Leaf & Debris Removal" />
@@ -573,7 +573,7 @@
           </p>
         </div>
       </div>
-      <div class="service-card" onclick="openServiceModal('Tractor / Bush Hog Services')" style="cursor: pointer">
+      <div class="service-card" onclick="openServiceModal('Tractor / Bush Hog Services')" style="cursor: pointer" role="button" tabindex="0">
         <div class="service-image bg-service-bushhog" role="img" aria-label="Tractor / Bush Hog Services">
           <noscript>
             <img src="images/bushhog.webp" alt="Tractor / Bush Hog Services" />
@@ -914,13 +914,13 @@
 
 
   <!-- Service Inquiry Modal -->
-  <div id="service-modal" class="modal">
+  <div id="service-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-service-title">
     <div class="modal-content">
       <div class="modal-header">
         <h2 id="modal-service-title">
           Request Service
         </h2>
-        <button onclick="closeServiceModal()" class="modal-close">
+        <button onclick="closeServiceModal()" class="modal-close" aria-label="Close">
           &times;
         </button>
       </div>
@@ -1045,17 +1045,25 @@
   </footer>
 
   <script>
+    let lastFocusedElement;
+
     function openServiceModal(serviceName) {
+      lastFocusedElement = document.activeElement;
       document.getElementById("modal-service-title").textContent =
         serviceName;
       document.getElementById("inquiry-service").value = serviceName;
       const modal = document.getElementById("service-modal");
       modal.style.display = "flex";
+      modal.classList.add("active");
+      document.getElementById("firstName").focus();
     }
 
     function closeServiceModal() {
-      document.getElementById("service-modal").style.display = "none";
+      const modal = document.getElementById("service-modal");
+      modal.style.display = "none";
+      modal.classList.remove("active");
       document.getElementById("service-inquiry-form").reset();
+      if (lastFocusedElement) lastFocusedElement.focus();
     }
 
     function handleServiceInquiry(e) {
@@ -1096,6 +1104,22 @@
         }
       });
 
+    // Close on Escape
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" && document.getElementById("service-modal").style.display === "flex") {
+        closeServiceModal();
+      }
+    });
+
+    // Keyboard support for service cards
+    document.querySelectorAll('.service-card').forEach(card => {
+      card.addEventListener('keydown', e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          card.click();
+        }
+      });
+    });
   </script>
   <script>
     document.addEventListener("DOMContentLoaded", function () {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -378,7 +378,7 @@
         <span class="navbar-tagline">LAWN CARE</span>
       </div>
     </div>
-    <button class="mobile-menu-btn" onclick="toggleMobileMenu()" aria-label="Toggle menu">
+    <button class="mobile-menu-btn" onclick="toggleMobileMenu()" aria-label="Toggle menu" aria-expanded="false">
       ☰
     </button>
     <div class="navbar-links" id="navbar-links">
@@ -1060,6 +1060,7 @@
 
     function closeServiceModal() {
       const modal = document.getElementById("service-modal");
+      if (!modal.classList.contains("active")) return;
       modal.style.display = "none";
       modal.classList.remove("active");
       document.getElementById("service-inquiry-form").reset();
@@ -1106,7 +1107,7 @@
 
     // Close on Escape
     document.addEventListener("keydown", function (e) {
-      if (e.key === "Escape" && document.getElementById("service-modal").style.display === "flex") {
+      if (e.key === "Escape") {
         closeServiceModal();
       }
     });
@@ -1136,17 +1137,17 @@
   <script>
     // Mobile menu toggle
     function toggleMobileMenu() {
-      document.getElementById("navbar-links").classList.toggle(
-        "active",
-      );
+      const links = document.getElementById("navbar-links");
+      const btn = document.querySelector(".mobile-menu-btn");
+      const isActive = links.classList.toggle("active");
+      btn.setAttribute("aria-expanded", isActive);
     }
 
     // Close mobile menu when clicking a link
     document.querySelectorAll(".navbar-link").forEach((link) => {
       link.addEventListener("click", () => {
-        document.getElementById("navbar-links").classList.remove(
-          "active",
-        );
+        document.getElementById("navbar-links").classList.remove("active");
+        document.querySelector(".mobile-menu-btn").setAttribute("aria-expanded", "false");
       });
     });
 

--- a/web/static/styles.premium.css
+++ b/web/static/styles.premium.css
@@ -180,6 +180,7 @@ h1, h2, h3,
   transition: transform 0.3s cubic-bezier(0.2, 0.7, 0.2, 1), box-shadow 0.3s;
 }
 .service-card:hover, .blog-card:hover, .card:hover { transform: translateY(-6px); box-shadow: var(--shadow-lg); }
+.service-card:focus-visible, .blog-card:focus-visible, .card:focus-visible { outline: 3px solid var(--x-gold); outline-offset: 4px; transform: translateY(-6px); }
 .service-card:focus-within, .blog-card:focus-within, .card:focus-within { transform: translateY(-6px); box-shadow: var(--shadow-lg); }
 .service-image, .blog-image {
   height: 200px; background-size: cover; background-position: center;


### PR DESCRIPTION
This PR implements a micro-UX improvement focused on accessibility and keyboard navigation for the main landing page.

💡 **What**: 
- Enhanced the `.service-card` elements to be keyboard-navigable and recognizable by screen readers.
- Significantly improved the `service-modal` accessibility by implementing standard ARIA patterns and robust focus management.
- Added visual focus indicators to cards using `:focus-visible` to match the "River Parish Botanical" premium skin.

🎯 **Why**: 
Icon-only buttons and interactive `div` elements were not accessible to keyboard users or screen reader users. The modal lacked standard accessibility features like "Escape" key support and focus management, which can be disorienting for users relying on assistive technology.

♿ **Accessibility**:
- Added `role="button"` and `tabindex="0"` to all interactive service cards.
- Added programmatic focus management: focusing the first input when the modal opens and restoring focus to the trigger element when it closes.
- Added `aria-label="Close"` to the modal close button.
- Added ARIA roles `dialog` and `aria-modal="true"` to the modal container.
- Implemented keyboard listeners for 'Enter', 'Space' (on cards), and 'Escape' (to close modal).
- Added `:focus-visible` outline styles for better visibility during keyboard navigation.

📸 **Verification**:
Verified using a Playwright script. The modal correctly traps focus on the first name field when opened via keyboard and restores focus to the original card when dismissed with the Escape key.

The changes were applied to both `home.html` and `index.html` to maintain consistency across the landing page variants.

---
*PR created automatically by Jules for task [4704824566737080931](https://jules.google.com/task/4704824566737080931) started by @Thelastlineofcode*