### PR TITLE
🎨 Palette: Landing Page Accessibility & Focus Lifecycle Improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-27 - Landing Page Component Accessibility (Mobile Menu and Service Inquiry Modal)
+**Learning:** Static landing pages (home.html and index.html) used manual JS state management for mobile menus and modals, leading to missing aria-expanded, dialog roles, and incomplete Focus Lifecycle tracking. Since there is no framework state (like React), custom vanilla JS event listeners and attribute updating must be utilized to maintain standard visual and screen-reader accessibility.
+**Action:** Always verify custom vanilla HTML/JS interactive components for aria-expanded toggles and focus preservation (capturing activeElement and restoring focus on close), especially when copies of identical landing pages (home.html/index.html) exist.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,52 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.44.0
+        version: 1.62.0
+
+packages:
+
+  '@playwright/test@1.62.0':
+    resolution: {integrity: sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.62.0:
+    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.0:
+    resolution: {integrity: sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+snapshots:
+
+  '@playwright/test@1.62.0':
+    dependencies:
+      playwright: 1.62.0
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.62.0: {}
+
+  playwright@1.62.0:
+    dependencies:
+      playwright-core: 1.62.0
+    optionalDependencies:
+      fsevents: 2.3.2

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/web/static/home.html
+++ b/web/static/home.html
@@ -378,7 +378,7 @@
         <span class="navbar-tagline">LAWN CARE</span>
       </div>
     </div>
-    <button class="mobile-menu-btn" onclick="toggleMobileMenu()" aria-label="Toggle menu">
+    <button class="mobile-menu-btn" onclick="toggleMobileMenu()" aria-label="Toggle menu" aria-expanded="false">
       ☰
     </button>
     <div class="navbar-links" id="navbar-links">
@@ -914,13 +914,13 @@
 
 
   <!-- Service Inquiry Modal -->
-  <div id="service-modal" class="modal">
+  <div id="service-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-service-title">
     <div class="modal-content">
       <div class="modal-header">
         <h2 id="modal-service-title">
           Request Service
         </h2>
-        <button onclick="closeServiceModal()" class="modal-close">
+        <button onclick="closeServiceModal()" class="modal-close" aria-label="Close">
           &times;
         </button>
       </div>
@@ -1045,18 +1045,36 @@
   </footer>
 
   <script>
+    let lastActiveElement = null;
+
     function openServiceModal(serviceName) {
       document.getElementById("modal-service-title").textContent =
         serviceName;
       document.getElementById("inquiry-service").value = serviceName;
       const modal = document.getElementById("service-modal");
+      lastActiveElement = document.activeElement;
       modal.style.display = "flex";
+      const firstInput = document.getElementById("firstName");
+      if (firstInput) firstInput.focus();
     }
 
     function closeServiceModal() {
       document.getElementById("service-modal").style.display = "none";
       document.getElementById("service-inquiry-form").reset();
+      if (lastActiveElement) {
+        lastActiveElement.focus();
+        lastActiveElement = null;
+      }
     }
+
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape") {
+        const modal = document.getElementById("service-modal");
+        if (modal && modal.style.display === "flex") {
+          closeServiceModal();
+        }
+      }
+    });
 
     function handleServiceInquiry(e) {
       e.preventDefault();
@@ -1112,9 +1130,10 @@
   <script>
     // Mobile menu toggle
     function toggleMobileMenu() {
-      document.getElementById("navbar-links").classList.toggle(
-        "active",
-      );
+      const links = document.getElementById("navbar-links");
+      const active = links.classList.toggle("active");
+      const btn = document.querySelector(".mobile-menu-btn");
+      if (btn) btn.setAttribute("aria-expanded", active ? "true" : "false");
     }
 
     // Close mobile menu when clicking a link
@@ -1123,6 +1142,8 @@
         document.getElementById("navbar-links").classList.remove(
           "active",
         );
+        const btn = document.querySelector(".mobile-menu-btn");
+        if (btn) btn.setAttribute("aria-expanded", "false");
       });
     });
 

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -378,7 +378,7 @@
         <span class="navbar-tagline">LAWN CARE</span>
       </div>
     </div>
-    <button class="mobile-menu-btn" onclick="toggleMobileMenu()" aria-label="Toggle menu">
+    <button class="mobile-menu-btn" onclick="toggleMobileMenu()" aria-label="Toggle menu" aria-expanded="false">
       ☰
     </button>
     <div class="navbar-links" id="navbar-links">
@@ -914,13 +914,13 @@
 
 
   <!-- Service Inquiry Modal -->
-  <div id="service-modal" class="modal">
+  <div id="service-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-service-title">
     <div class="modal-content">
       <div class="modal-header">
         <h2 id="modal-service-title">
           Request Service
         </h2>
-        <button onclick="closeServiceModal()" class="modal-close">
+        <button onclick="closeServiceModal()" class="modal-close" aria-label="Close">
           &times;
         </button>
       </div>
@@ -1045,18 +1045,36 @@
   </footer>
 
   <script>
+    let lastActiveElement = null;
+
     function openServiceModal(serviceName) {
       document.getElementById("modal-service-title").textContent =
         serviceName;
       document.getElementById("inquiry-service").value = serviceName;
       const modal = document.getElementById("service-modal");
+      lastActiveElement = document.activeElement;
       modal.style.display = "flex";
+      const firstInput = document.getElementById("firstName");
+      if (firstInput) firstInput.focus();
     }
 
     function closeServiceModal() {
       document.getElementById("service-modal").style.display = "none";
       document.getElementById("service-inquiry-form").reset();
+      if (lastActiveElement) {
+        lastActiveElement.focus();
+        lastActiveElement = null;
+      }
     }
+
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape") {
+        const modal = document.getElementById("service-modal");
+        if (modal && modal.style.display === "flex") {
+          closeServiceModal();
+        }
+      }
+    });
 
     function handleServiceInquiry(e) {
       e.preventDefault();
@@ -1112,9 +1130,10 @@
   <script>
     // Mobile menu toggle
     function toggleMobileMenu() {
-      document.getElementById("navbar-links").classList.toggle(
-        "active",
-      );
+      const links = document.getElementById("navbar-links");
+      const active = links.classList.toggle("active");
+      const btn = document.querySelector(".mobile-menu-btn");
+      if (btn) btn.setAttribute("aria-expanded", active ? "true" : "false");
     }
 
     // Close mobile menu when clicking a link
@@ -1123,6 +1142,8 @@
         document.getElementById("navbar-links").classList.remove(
           "active",
         );
+        const btn = document.querySelector(".mobile-menu-btn");
+        if (btn) btn.setAttribute("aria-expanded", "false");
       });
     });
 

--- a/web/tests/playwright.config.ts
+++ b/web/tests/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   use: {
-    baseURL: Deno.env.get("TEST_BASE_URL") || "http://127.0.0.1:8000",
+    baseURL: (typeof Deno !== "undefined" ? Deno.env.get("TEST_BASE_URL") : process.env.TEST_BASE_URL) || "http://127.0.0.1:8000",
     headless: true,
     ignoreHTTPSErrors: true,
     viewport: { width: 1280, height: 720 },


### PR DESCRIPTION
🎨 Palette: Landing Page Accessibility & Focus Lifecycle Improvements

💡 What:
We have implemented critical screen-reader and keyboard accessibility improvements on both landing pages (`home.html` and `index.html`).
- Added `aria-expanded` attributes on the mobile menu triggers, updating programmatically in JavaScript.
- Enhanced the Service Inquiry Modal by adding `role="dialog"`, `aria-modal="true"`, and `aria-labelledby="modal-service-title"`.
- Appended `aria-label="Close"` to the modal close buttons for screen readers.
- Implemented a complete Focus Lifecycle: capturing the last focused element before modal open, auto-focusing the first interactive input field (`firstName`), allowing modal close via the `Escape` key, and restoring focus back to the triggering element upon close.
- Conditionals were added to `playwright.config.ts` to seamlessly handle `Deno.env` checks during Node/pnpm test runs.

🎯 Why:
This solves critical accessibility issues, ensuring that the main landing pages are friendly to assistive technologies (screen-readers) and keyboard-only users.

♿ Accessibility:
- Full support for screen readers via ARIA dialog and expanded states, and localized close-button labels.
- Fluid keyboard navigation with Focus preservation/restoration and standard Escape key triggers.

---
*PR created automatically by Jules for task [3204931788936878771](https://jules.google.com/task/3204931788936878771) started by @Thelastlineofcode*