### PR TITLE
🎨 Palette: Enhance static pages accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-02 - Enhancing Non-Semantic Interactive Element Accessibility
+**Learning:** In marketing sites built with non-semantic grid items (like service cards), relying solely on `onclick` handlers on generic `div` tags breaks keyboard navigation. Users navigating via screen-reader or keyboard tab navigation cannot focus or interact with these elements.
+**Action:** Always add `role="button"` and `tabindex="0"` programmatically or explicitly, and ensure keydown events handle both 'Enter' and 'Space' with appropriate `preventDefault()` to prevent scrolling.

--- a/web/static/home.html
+++ b/web/static/home.html
@@ -378,7 +378,7 @@
         <span class="navbar-tagline">LAWN CARE</span>
       </div>
     </div>
-    <button class="mobile-menu-btn" onclick="toggleMobileMenu()" aria-label="Toggle menu">
+    <button class="mobile-menu-btn" onclick="toggleMobileMenu()" aria-label="Toggle menu" aria-expanded="false">
       ☰
     </button>
     <div class="navbar-links" id="navbar-links">
@@ -914,13 +914,13 @@
 
 
   <!-- Service Inquiry Modal -->
-  <div id="service-modal" class="modal">
+  <div id="service-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-service-title">
     <div class="modal-content">
       <div class="modal-header">
         <h2 id="modal-service-title">
           Request Service
         </h2>
-        <button onclick="closeServiceModal()" class="modal-close">
+        <button onclick="closeServiceModal()" class="modal-close" aria-label="Close">
           &times;
         </button>
       </div>
@@ -1045,18 +1045,49 @@
   </footer>
 
   <script>
+    let previousActiveElement = null;
+
     function openServiceModal(serviceName) {
-      document.getElementById("modal-service-title").textContent =
-        serviceName;
+      previousActiveElement = document.activeElement;
+      document.getElementById("modal-service-title").textContent = serviceName;
       document.getElementById("inquiry-service").value = serviceName;
       const modal = document.getElementById("service-modal");
       modal.style.display = "flex";
+      setTimeout(() => {
+        const firstInput = document.getElementById("firstName");
+        if (firstInput) firstInput.focus();
+      }, 50);
     }
 
     function closeServiceModal() {
       document.getElementById("service-modal").style.display = "none";
       document.getElementById("service-inquiry-form").reset();
+      if (previousActiveElement && typeof previousActiveElement.focus === "function") {
+        previousActiveElement.focus();
+      }
     }
+
+    document.addEventListener("keydown", function(e) {
+      if (e.key === "Escape") {
+        const modal = document.getElementById("service-modal");
+        if (modal && modal.style.display === "flex") {
+          closeServiceModal();
+        }
+      }
+    });
+
+    document.addEventListener("DOMContentLoaded", () => {
+      document.querySelectorAll(".service-card").forEach(card => {
+        card.setAttribute("role", "button");
+        card.setAttribute("tabindex", "0");
+        card.addEventListener("keydown", (e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            card.click();
+          }
+        });
+      });
+    });
 
     function handleServiceInquiry(e) {
       e.preventDefault();
@@ -1112,9 +1143,12 @@
   <script>
     // Mobile menu toggle
     function toggleMobileMenu() {
-      document.getElementById("navbar-links").classList.toggle(
-        "active",
-      );
+      const links = document.getElementById("navbar-links");
+      const btn = document.querySelector(".mobile-menu-btn");
+      const isActive = links.classList.toggle("active");
+      if (btn) {
+        btn.setAttribute("aria-expanded", isActive ? "true" : "false");
+      }
     }
 
     // Close mobile menu when clicking a link

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -378,7 +378,7 @@
         <span class="navbar-tagline">LAWN CARE</span>
       </div>
     </div>
-    <button class="mobile-menu-btn" onclick="toggleMobileMenu()" aria-label="Toggle menu">
+    <button class="mobile-menu-btn" onclick="toggleMobileMenu()" aria-label="Toggle menu" aria-expanded="false">
       ☰
     </button>
     <div class="navbar-links" id="navbar-links">
@@ -914,13 +914,13 @@
 
 
   <!-- Service Inquiry Modal -->
-  <div id="service-modal" class="modal">
+  <div id="service-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-service-title">
     <div class="modal-content">
       <div class="modal-header">
         <h2 id="modal-service-title">
           Request Service
         </h2>
-        <button onclick="closeServiceModal()" class="modal-close">
+        <button onclick="closeServiceModal()" class="modal-close" aria-label="Close">
           &times;
         </button>
       </div>
@@ -1045,18 +1045,49 @@
   </footer>
 
   <script>
+    let previousActiveElement = null;
+
     function openServiceModal(serviceName) {
-      document.getElementById("modal-service-title").textContent =
-        serviceName;
+      previousActiveElement = document.activeElement;
+      document.getElementById("modal-service-title").textContent = serviceName;
       document.getElementById("inquiry-service").value = serviceName;
       const modal = document.getElementById("service-modal");
       modal.style.display = "flex";
+      setTimeout(() => {
+        const firstInput = document.getElementById("firstName");
+        if (firstInput) firstInput.focus();
+      }, 50);
     }
 
     function closeServiceModal() {
       document.getElementById("service-modal").style.display = "none";
       document.getElementById("service-inquiry-form").reset();
+      if (previousActiveElement && typeof previousActiveElement.focus === "function") {
+        previousActiveElement.focus();
+      }
     }
+
+    document.addEventListener("keydown", function(e) {
+      if (e.key === "Escape") {
+        const modal = document.getElementById("service-modal");
+        if (modal && modal.style.display === "flex") {
+          closeServiceModal();
+        }
+      }
+    });
+
+    document.addEventListener("DOMContentLoaded", () => {
+      document.querySelectorAll(".service-card").forEach(card => {
+        card.setAttribute("role", "button");
+        card.setAttribute("tabindex", "0");
+        card.addEventListener("keydown", (e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            card.click();
+          }
+        });
+      });
+    });
 
     function handleServiceInquiry(e) {
       e.preventDefault();
@@ -1112,9 +1143,12 @@
   <script>
     // Mobile menu toggle
     function toggleMobileMenu() {
-      document.getElementById("navbar-links").classList.toggle(
-        "active",
-      );
+      const links = document.getElementById("navbar-links");
+      const btn = document.querySelector(".mobile-menu-btn");
+      const isActive = links.classList.toggle("active");
+      if (btn) {
+        btn.setAttribute("aria-expanded", isActive ? "true" : "false");
+      }
     }
 
     // Close mobile menu when clicking a link

--- a/web/static/styles.premium.css
+++ b/web/static/styles.premium.css
@@ -181,6 +181,7 @@ h1, h2, h3,
 }
 .service-card:hover, .blog-card:hover, .card:hover { transform: translateY(-6px); box-shadow: var(--shadow-lg); }
 .service-card:focus-within, .blog-card:focus-within, .card:focus-within { transform: translateY(-6px); box-shadow: var(--shadow-lg); }
+.service-card:focus-visible, .blog-card:focus-visible, .card:focus-visible { transform: translateY(-6px); box-shadow: var(--shadow-lg); outline: 2px solid var(--x-green); outline-offset: 4px; }
 .service-image, .blog-image {
   height: 200px; background-size: cover; background-position: center;
   transition: transform 0.5s cubic-bezier(0.2, 0.7, 0.2, 1);

--- a/web/tests/e2e/accessibility.spec.ts
+++ b/web/tests/e2e/accessibility.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+import path from "node:path";
+
+const homeHtmlPath = `file://${path.resolve("web/static/home.html")}`;
+
+test("Home page accessibility enhancements are correct", async ({ page }) => {
+  // Set to mobile viewport size so the mobile menu button is visible
+  await page.setViewportSize({ width: 375, height: 667 });
+  await page.goto(homeHtmlPath);
+
+  // 1. Mobile menu button check
+  const mobileMenuBtn = page.locator(".mobile-menu-btn");
+  await expect(mobileMenuBtn).toBeVisible();
+  await expect(mobileMenuBtn).toHaveAttribute("aria-expanded", "false");
+
+  // Toggle mobile menu and verify updated attribute
+  await mobileMenuBtn.click();
+  await expect(mobileMenuBtn).toHaveAttribute("aria-expanded", "true");
+
+  // 2. Service card focusability and roles
+  const serviceCards = page.locator(".service-card");
+  const count = await serviceCards.count();
+  expect(count).toBeGreaterThan(0);
+
+  for (let i = 0; i < count; i++) {
+    const card = serviceCards.nth(i);
+    await expect(card).toHaveAttribute("role", "button");
+    await expect(card).toHaveAttribute("tabindex", "0");
+  }
+
+  // 3. Service inquiry modal accessibility attributes
+  const modal = page.locator("#service-modal");
+  await expect(modal).toHaveAttribute("role", "dialog");
+  await expect(modal).toHaveAttribute("aria-modal", "true");
+  await expect(modal).toHaveAttribute("aria-labelledby", "modal-service-title");
+
+  // 4. Modal close button accessibility label
+  const closeBtn = modal.locator(".modal-close");
+  await expect(closeBtn).toHaveAttribute("aria-label", "Close");
+});

--- a/web/tests/playwright.config.ts
+++ b/web/tests/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   use: {
-    baseURL: Deno.env.get("TEST_BASE_URL") || "http://127.0.0.1:8000",
+    baseURL: (typeof Deno !== "undefined" ? Deno.env.get("TEST_BASE_URL") : undefined) || "http://127.0.0.1:8000",
     headless: true,
     ignoreHTTPSErrors: true,
     viewport: { width: 1280, height: 720 },


### PR DESCRIPTION
### 🎨 Palette: Accessibility & UX Improvements

#### 💡 What:
- **Mobile Menu Accessibility:** Added `aria-expanded` state tracking to the mobile navigation toggle button.
- **Service Inquiry Modal:** Upgraded `#service-modal` container with ARIA roles (`role='dialog'`, `aria-modal='true'`) and connected it to its heading with `aria-labelledby`. Added an explicit `aria-label='Close'` to the close button.
- **Focus Lifecycle Management:** Captured the previously focused element prior to modal opening, automatically focused the `First Name` input field on opening, added an `Escape` key listener to close the modal, and restored focus to the triggering element on closing.
- **Service Card Navigation:** Programmatically converted non-semantic `.service-card` elements into keyboard-interactive focus targets with `role='button'` and `tabindex='0'`, handling both `Enter` and `Space` key actions.
- **Focus styling:** Added `:focus-visible` outline styles in CSS.

#### 🎯 Why:
To ensure the application's main landing pages conform to standard web accessibility standards for screen-reader and keyboard users.

#### ♿ Accessibility & Visual Verification:
- Added a new automated Playwright test: `web/tests/e2e/accessibility.spec.ts`.
- Generated and verified a visual screenshot of the focused input within the modal.

---
*PR created automatically by Jules for task [642816719635022584](https://jules.google.com/task/642816719635022584) started by @Thelastlineofcode*