### PR TITLE
🎨 Palette: Enhance Service Inquiry Modal Accessibility & Focus Lifecycle

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,52 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.44.0
+        version: 1.62.1
+
+packages:
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+snapshots:
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/web/static/home.html
+++ b/web/static/home.html
@@ -914,13 +914,13 @@
 
 
   <!-- Service Inquiry Modal -->
-  <div id="service-modal" class="modal">
+  <div id="service-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-service-title">
     <div class="modal-content">
       <div class="modal-header">
         <h2 id="modal-service-title">
           Request Service
         </h2>
-        <button onclick="closeServiceModal()" class="modal-close">
+        <button onclick="closeServiceModal()" class="modal-close" aria-label="Close">
           &times;
         </button>
       </div>
@@ -1045,18 +1045,37 @@
   </footer>
 
   <script>
+    let previousActiveElement = null;
+
     function openServiceModal(serviceName) {
+      previousActiveElement = document.activeElement;
       document.getElementById("modal-service-title").textContent =
         serviceName;
       document.getElementById("inquiry-service").value = serviceName;
       const modal = document.getElementById("service-modal");
       modal.style.display = "flex";
+      setTimeout(() => {
+        document.getElementById("firstName")?.focus();
+      }, 50);
     }
 
     function closeServiceModal() {
-      document.getElementById("service-modal").style.display = "none";
+      const modal = document.getElementById("service-modal");
+      modal.style.display = "none";
       document.getElementById("service-inquiry-form").reset();
+      if (previousActiveElement && typeof previousActiveElement.focus === "function") {
+        previousActiveElement.focus();
+      }
     }
+
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape") {
+        const modal = document.getElementById("service-modal");
+        if (modal && modal.style.display === "flex") {
+          closeServiceModal();
+        }
+      }
+    });
 
     function handleServiceInquiry(e) {
       e.preventDefault();

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -914,13 +914,13 @@
 
 
   <!-- Service Inquiry Modal -->
-  <div id="service-modal" class="modal">
+  <div id="service-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-service-title">
     <div class="modal-content">
       <div class="modal-header">
         <h2 id="modal-service-title">
           Request Service
         </h2>
-        <button onclick="closeServiceModal()" class="modal-close">
+        <button onclick="closeServiceModal()" class="modal-close" aria-label="Close">
           &times;
         </button>
       </div>
@@ -1045,18 +1045,37 @@
   </footer>
 
   <script>
+    let previousActiveElement = null;
+
     function openServiceModal(serviceName) {
+      previousActiveElement = document.activeElement;
       document.getElementById("modal-service-title").textContent =
         serviceName;
       document.getElementById("inquiry-service").value = serviceName;
       const modal = document.getElementById("service-modal");
       modal.style.display = "flex";
+      setTimeout(() => {
+        document.getElementById("firstName")?.focus();
+      }, 50);
     }
 
     function closeServiceModal() {
-      document.getElementById("service-modal").style.display = "none";
+      const modal = document.getElementById("service-modal");
+      modal.style.display = "none";
       document.getElementById("service-inquiry-form").reset();
+      if (previousActiveElement && typeof previousActiveElement.focus === "function") {
+        previousActiveElement.focus();
+      }
     }
+
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape") {
+        const modal = document.getElementById("service-modal");
+        if (modal && modal.style.display === "flex") {
+          closeServiceModal();
+        }
+      }
+    });
 
     function handleServiceInquiry(e) {
       e.preventDefault();

--- a/web/tests/playwright.config.ts
+++ b/web/tests/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   use: {
-    baseURL: Deno.env.get("TEST_BASE_URL") || "http://127.0.0.1:8000",
+    baseURL: (typeof Deno !== "undefined" ? Deno.env.get("TEST_BASE_URL") : process.env.TEST_BASE_URL) || "http://127.0.0.1:8000",
     headless: true,
     ignoreHTTPSErrors: true,
     viewport: { width: 1280, height: 720 },


### PR DESCRIPTION
🎨 Palette: Enhance Service Inquiry Modal Accessibility & Focus Lifecycle

💡 What: Added ARIA dialog attributes (`role="dialog"`, `aria-modal="true"`, `aria-labelledby="modal-service-title"`), explicit `aria-label="Close"` on the close button, focus management on open/close (`#firstName` input focus & previous element focus restoration), and Escape key press handling to close the modal in both `web/static/home.html` and `web/static/index.html`.

🎯 Why: Users navigating with keyboard or screen readers had difficulty identifying and managing the service inquiry modal. Focus was not managed automatically upon opening, and pressing Escape did not close the modal dialog.

♿ Accessibility:
- Added proper ARIA role and labeling for screen readers.
- Added explicit ARIA label for symbol-only close button (`&times;`).
- Programmatically managed focus lifecycle on open and restore on close.
- Enabled Escape key listener to close modal seamlessly.

---
*PR created automatically by Jules for task [12247884977806175229](https://jules.google.com/task/12247884977806175229) started by @Thelastlineofcode*